### PR TITLE
Add tl;dr sec to list of blogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ If you enjoy this awesome list and would like to support it, check out my [Patre
 - [The Magic of Learning](https://bitvijays.github.io/) - Written by [@bitvijays](https://bitvijays.github.io/aboutme.html).
 - [CTF Field Guide](https://trailofbits.github.io/ctf/) - Written by [Trail of Bits](https://www.trailofbits.com/).
 - [PayloadsAllTheThings](https://github.com/swisskyrepo/PayloadsAllTheThings/) - Written by [@swisskyrepo](https://github.com/swisskyrepo).
+- [tl;dr sec](https://tldrsec.com/) - Weekly summary of top security tools, blog posts, and security research.
 
 ## Forums
 
@@ -790,7 +791,6 @@ If you enjoy this awesome list and would like to support it, check out my [Patre
 - [RIPS Technologies](https://blog.ripstech.com/tags/security/) - Write-ups for PHP vulnerabilities.
 - [0Day Labs](http://blog.0daylabs.com/) - Awesome bug-bounty and challenges writeups.
 - [Blog of Osanda](https://osandamalith.com/) - Security Researching and Reverse Engineering.
-- [tl;dr sec](https://tldrsec.com/) - Weekly summary of top security tools, blog posts, and security research.
 
 ## Twitter Users
 

--- a/README.md
+++ b/README.md
@@ -790,6 +790,7 @@ If you enjoy this awesome list and would like to support it, check out my [Patre
 - [RIPS Technologies](https://blog.ripstech.com/tags/security/) - Write-ups for PHP vulnerabilities.
 - [0Day Labs](http://blog.0daylabs.com/) - Awesome bug-bounty and challenges writeups.
 - [Blog of Osanda](https://osandamalith.com/) - Security Researching and Reverse Engineering.
+- [tl;dr sec](https://tldrsec.com/) - Weekly summary of top security tools, blog posts, and security research.
 
 ## Twitter Users
 


### PR DESCRIPTION
Hey! 👋 Thanks so much for putting together this repo, tons of awesome resources here 🙏 

This PR adds a link to a newsletter/blog I write that aims to collect useful security tools, blog posts, and current research to help people keep up with the massive amount of content out there. 

It covers a number of security areas, not just web security, so let me know if it isn't a good fit for this list. No problem if not :) 

Here's an example of some previous web security content: 
  https://tldrsec.com/blog/tldr-sec-044/#towards-native-security-defenses-for-the-web-ecosystem.