### PR TITLE
Adds MutableSecurity to Preventing Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,6 +739,7 @@ If you enjoy this awesome list and would like to support it, check out my [Patre
 - [js-xss](https://github.com/leizongmin/js-xss) - Sanitize untrusted HTML (to prevent XSS) with a configuration specified by a Whitelist by [@leizongmin](https://github.com/leizongmin).
 - [Acra](https://github.com/cossacklabs/acra) - Client-side encryption engine for SQL databases, with strong selective encryption, SQL injections prevention and intrusion detection by [@cossacklabs](https://www.cossacklabs.com/).
 - [Csper](https://csper.io) - A set of tools for building/evaluating/monitoring content-security-policy to prevent/detect cross site scripting by [Csper](https://csper.io).
+- [MutableSecurity](https://github.com/MutableSecurity/mutablesecurity) - CLI program for automating the setup, configuration, and use of cybersecurity solutions (for example, [teler](https://github.com/kitabisa/teler), a web intrusion detection system).
 
 <a name="tools-proxy"></a>
 ### Proxy


### PR DESCRIPTION
The pull request adds [MutableSecurity](https://github.com/MutableSecurity/mutablesecurity), a CLI tool for managing the lifecycle of cybersecurity solutions, to Preventing Tools.