### PR TITLE
Add Certificate Ripper

### DIFF
--- a/README.md
+++ b/README.md
@@ -785,6 +785,7 @@ If you enjoy this awesome list and would like to support it, check out my [Patre
 - [ntlm_challenger](https://github.com/b17zr/ntlm_challenger) - Parse NTLM over HTTP challenge messages by [@b17zr](https://github.com/b17zr).
 - [cefdebug](https://github.com/taviso/cefdebug) - Minimal code to connect to a CEF debugger by [@taviso](https://github.com/taviso).
 - [ctftool](https://github.com/taviso/ctftool) - Interactive CTF Exploration Tool by [@taviso](https://github.com/taviso).
+- [Certificate Ripper](https://github.com/Hakky54/certificate-ripper) - A CLI tool to extracts server certificates by [@hakky54](https://github.com/Hakky54).
 
 ## Social Engineering Database
 


### PR DESCRIPTION
[Certificate ripper](https://github.com/Hakky54/certificate-ripper) is a CLI tool to easily extract the full chain of any server/website either in pem format or human-readable format. The end user can inspect any sub fields and details easily on the command line. Next to that it can also save the certificates in a der, p7b, pem and pkcs12 container.  

## Demo
![alt text](https://github.com/Hakky54/certificate-ripper/blob/master/images/demo.gif?raw=true)