### PR TITLE
Add IntoDNS.ai to Reconnaissance tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,6 +611,7 @@ If you enjoy this awesome list and would like to support it, check out my [Patre
 - [Photon](https://github.com/s0md3v/Photon) - Incredibly fast crawler designed for OSINT by [@s0md3v](https://github.com/s0md3v).
 - [FOCA](https://github.com/ElevenPaths/FOCA) - FOCA (Fingerprinting Organizations with Collected Archives) is a tool used mainly to find metadata and hidden information in the documents its scans by [ElevenPaths](https://www.elevenpaths.com/index.html).
 - [SpiderFoot](http://www.spiderfoot.net/) - Open source footprinting and intelligence-gathering tool by [@binarypool](https://twitter.com/binarypool).
+- [IntoDNS.ai](https://intodns.ai/) - Free DNS and email security scanner checking SPF, DKIM, DMARC, DNSSEC, MTA-STS, and 40+ blacklists.
 - [xray](https://github.com/evilsocket/xray) - XRay is a tool for recon, mapping and OSINT gathering from public networks by [@evilsocket](https://github.com/evilsocket).
 - [gitrob](https://github.com/michenriksen/Gitrob) - Reconnaissance tool for GitHub organizations by [@michenriksen](https://github.com/michenriksen).
 - [GSIL](https://github.com/FeeiCN/GSIL) - Github Sensitive Information Leakage（Github敏感信息泄露）by [@FeeiCN](https://github.com/FeeiCN).


### PR DESCRIPTION
Adding IntoDNS.ai to the OSINT/Reconnaissance section — free DNS and email security scanner. Checks SPF, DKIM, DMARC, DNSSEC, MTA-STS and 40+ blacklists. Useful for quick domain recon.

— Jeroen, Cobytes B.V.