### PR TITLE
Add MANTIS WAF Detector to Tools > Reconnaissance > OSINT

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,6 +622,7 @@ If you enjoy this awesome list and would like to support it, check out my [Patre
 - [Raccoon](https://github.com/evyatarmeged/Raccoon) - High performance offensive security tool for reconnaissance and vulnerability scanning by [@evyatarmeged](https://github.com/evyatarmeged).
 - [Social Mapper](https://github.com/SpiderLabs/social_mapper) - Social Media Enumeration & Correlation Tool by Jacob Wilkin(Greenwolf) by [@SpiderLabs](https://github.com/SpiderLabs).
 - [espi0n/Dockerfiles](https://github.com/espi0n/Dockerfiles) - Dockerfiles for various OSINT tools by [@espi0n](https://github.com/espi0n).
+- [MANTIS WAF Detector](https://mantiscore.ai/free-tools/waf-detect) - Free hosted tool that identifies which of 75+ WAF vendors sits in front of a target URL. Resolves the URL, follows redirects, sends two probes, and returns the best match with raw evidence and runner-up matches.
 
 <a name="tools-sub-domain-enumeration"></a>
 #### Sub Domain Enumeration


### PR DESCRIPTION
Adding **MANTIS WAF Detector** (https://mantiscore.ai/free-tools/waf-detect) to **Tools > Reconnaissance > OSINT**, alongside urlscan.io, Shodan, and Censys.

What it does:
- Resolves the URL (handles `http`→`https` redirects and `apex`→`www` flips)
- Sends two probes (clean GET + payload probe) to the final URL after walking redirects
- Matches response headers, cookies, body patterns, and status codes against signatures for 75+ WAF vendors (Cloudflare, AWS WAF, Akamai, Imperva, Fastly, F5 BIG-IP, Citrix NetScaler, ModSecurity, NAXSI, Wallarm, Wordfence, Sucuri, StackPath, DataDome, PerimeterX, Reblaze, plus regional vendors like Alibaba, Tencent EdgeOne, NSFOCUS, Yundun, etc.)
- Returns best match with confidence score, raw evidence, and runner-up matches

It's free, hosted, no signup. Same peer set as urlscan.io (also a hosted SaaS recon tool) which is already in this section.

Per `CONTRIBUTING.md`:
- [x] Single suggestion in this PR
- [x] Format: `[Name](link) - Description.`
- [x] Description is one line, clear and concise
- [x] No duplicates (checked existing entries)