### PR TITLE
Fix Cybersecurity Campaign Playbook URL

### DIFF
--- a/README-jp.md
+++ b/README-jp.md
@@ -876,7 +876,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 - [awesome-bug-bounty](https://github.com/djadmin/awesome-bug-bounty) - Comprehensive curated list of available Bug Bounty & Disclosure Programs and write-ups by [@djadmin](https://github.com/djadmin).
 - [Brute Forcing Your Facebook Email and Phone Number](http://pwndizzle.blogspot.jp/2014/02/brute-forcing-your-facebook-email-and.html) - Written by [PwnDizzle](http://pwndizzle.blogspot.jp/).
 - [bug-bounty-reference](https://github.com/ngalongc/bug-bounty-reference) - List of bug bounty write-up that is categorized by the bug nature by [@ngalongc](https://github.com/ngalongc).
-- [Cybersecurity Campaign Playbook](https://www.belfercenter.org/CyberPlaybook) - Written by [Belfer Center for Science and International Affairs](https://www.belfercenter.org/).
+- [Cybersecurity Campaign Playbook](https://www.belfercenter.org/publication/cybersecurity-campaign-playbook) - Written by [Belfer Center for Science and International Affairs](https://www.belfercenter.org/).
 - [EQGRP](https://github.com/x0rz/EQGRP) - Decrypted content of eqgrp-auction-file.tar.xz by [@x0rz](https://github.com/x0rz).
 - [Google VRP and Unicorns](https://sites.google.com/site/bughunteruniversity/behind-the-scenes/presentations/google-vrp-and-unicorns) - Written by [Daniel Stelter-Gliese](https://www.linkedin.com/in/daniel-stelter-gliese-170a70a2/).
 - [Infosec_Reference](https://github.com/rmusser01/Infosec_Reference) - Information Security Reference That Doesn't Suck by [@rmusser01](https://github.com/rmusser01).

--- a/README-zh.md
+++ b/README-zh.md
@@ -929,7 +929,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 - [awesome-bug-bounty](https://github.com/djadmin/awesome-bug-bounty) - Comprehensive curated list of available Bug Bounty & Disclosure Programs and write-ups by [@djadmin](https://github.com/djadmin).
 - [Brute Forcing Your Facebook Email and Phone Number](http://pwndizzle.blogspot.jp/2014/02/brute-forcing-your-facebook-email-and.html) - Written by [PwnDizzle](http://pwndizzle.blogspot.jp/).
 - [bug-bounty-reference](https://github.com/ngalongc/bug-bounty-reference) - List of bug bounty write-up that is categorized by the bug nature by [@ngalongc](https://github.com/ngalongc).
-- [Cybersecurity Campaign Playbook](https://www.belfercenter.org/CyberPlaybook) - Written by [Belfer Center for Science and International Affairs](https://www.belfercenter.org/).
+- [Cybersecurity Campaign Playbook](https://www.belfercenter.org/publication/cybersecurity-campaign-playbook) - Written by [Belfer Center for Science and International Affairs](https://www.belfercenter.org/).
 - [EQGRP](https://github.com/x0rz/EQGRP) - Decrypted content of eqgrp-auction-file.tar.xz by [@x0rz](https://github.com/x0rz).
 - [Google VRP and Unicorns](https://sites.google.com/site/bughunteruniversity/behind-the-scenes/presentations/google-vrp-and-unicorns) - Written by [Daniel Stelter-Gliese](https://www.linkedin.com/in/daniel-stelter-gliese-170a70a2/).
 - [Infosec_Reference](https://github.com/rmusser01/Infosec_Reference) - Information Security Reference That Doesn't Suck by [@rmusser01](https://github.com/rmusser01).

--- a/README.md
+++ b/README.md
@@ -884,7 +884,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 - [awesome-bug-bounty](https://github.com/djadmin/awesome-bug-bounty) - Comprehensive curated list of available Bug Bounty & Disclosure Programs and write-ups by [@djadmin](https://github.com/djadmin).
 - [Brute Forcing Your Facebook Email and Phone Number](http://pwndizzle.blogspot.jp/2014/02/brute-forcing-your-facebook-email-and.html) - Written by [PwnDizzle](http://pwndizzle.blogspot.jp/).
 - [bug-bounty-reference](https://github.com/ngalongc/bug-bounty-reference) - List of bug bounty write-up that is categorized by the bug nature by [@ngalongc](https://github.com/ngalongc).
-- [Cybersecurity Campaign Playbook](https://www.belfercenter.org/CyberPlaybook) - Written by [Belfer Center for Science and International Affairs](https://www.belfercenter.org/).
+- [Cybersecurity Campaign Playbook](https://www.belfercenter.org/publication/cybersecurity-campaign-playbook) - Written by [Belfer Center for Science and International Affairs](https://www.belfercenter.org/).
 - [EQGRP](https://github.com/x0rz/EQGRP) - Decrypted content of eqgrp-auction-file.tar.xz by [@x0rz](https://github.com/x0rz).
 - [Google VRP and Unicorns](https://sites.google.com/site/bughunteruniversity/behind-the-scenes/presentations/google-vrp-and-unicorns) - Written by [Daniel Stelter-Gliese](https://www.linkedin.com/in/daniel-stelter-gliese-170a70a2/).
 - [Infosec_Reference](https://github.com/rmusser01/Infosec_Reference) - Information Security Reference That Doesn't Suck by [@rmusser01](https://github.com/rmusser01).

--- a/data/entries/miscellaneous.yml
+++ b/data/entries/miscellaneous.yml
@@ -51,7 +51,7 @@ entries:
     status: active
     raw_rest: "Written by [PwnDizzle](http://pwndizzle.blogspot.jp/)."
   - id: miscellaneous-cybersecurity-campaign-playbook
-    url: "https://www.belfercenter.org/CyberPlaybook"
+    url: "https://www.belfercenter.org/publication/cybersecurity-campaign-playbook"
     title: Cybersecurity Campaign Playbook
     author:
       name: Belfer Center for Science and International Affairs

--- a/data/index.json
+++ b/data/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-05-12T09:26:34Z",
+  "generated_at": "2026-05-12T09:37:30Z",
   "categories": [
     {
       "key": "digests",
@@ -3860,7 +3860,7 @@
     },
     {
       "id": "miscellaneous-cybersecurity-campaign-playbook",
-      "url": "https://www.belfercenter.org/CyberPlaybook",
+      "url": "https://www.belfercenter.org/publication/cybersecurity-campaign-playbook",
       "title": "Cybersecurity Campaign Playbook",
       "author": {
         "name": "Belfer Center for Science and International Affairs",


### PR DESCRIPTION
Updates the Cybersecurity Campaign Playbook entry to Belfer Center’s current canonical publication URL.

Why:
- The old `https://www.belfercenter.org/CyberPlaybook` URL now returns 404.
- The replacement URL returns 200 and points to the same Belfer resource.
- Regenerated the README files and JSON index from the YAML source.

Verification:
- `curl -L --max-time 20 -o /dev/null -s -w '%{http_code} %{url_effective}\n' https://www.belfercenter.org/publication/cybersecurity-campaign-playbook` -> 200
- `python3 scripts/generate.py`
- `python3 scripts/verify_schema.py`
- `git diff --check`

Addresses one broken entry from #176.