### PR TITLE
Fix dead GitHub Enterprise RCE resource link

### DIFF
--- a/README-jp.md
+++ b/README-jp.md
@@ -473,7 +473,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 
 - [DRUPAL 7.X SERVICES MODULE UNSERIALIZE() TO RCE](https://www.ambionics.io/blog/drupal-services-module-rce) - Written by [Ambionics Security](https://www.ambionics.io/).
 - [Exploiting Node.js deserialization bug for Remote Code Execution](https://opsecx.com/index.php/2017/02/08/exploiting-node-js-deserialization-bug-for-remote-code-execution/) - Written by [OpSecX](https://opsecx.com/index.php/author/ajinabraham/).
-- [GitHub Enterprise Remote Code Execution](http://exablue.de/blog/2017-03-15-github-enterprise-remote-code-execution.html) - Written by [@iblue](https://github.com/iblue).
+- [GitHub Enterprise Remote Code Execution](https://bounty.github.com/researchers/iblue.html) - Written by [@iblue](https://github.com/iblue).
 - [How I Chained 4 vulnerabilities on GitHub Enterprise, From SSRF Execution Chain to RCE!](http://blog.orange.tw/2017/07/how-i-chained-4-vulnerabilities-on.html) - Written by [Orange](http://blog.orange.tw/).
 - [How we exploited a remote code execution vulnerability in math.js](https://capacitorset.github.io/mathjs/) - Written by [@capacitorset](https://github.com/capacitorset).
 - [$36k Google App Engine RCE](https://sites.google.com/site/testsitehacking/-36k-google-app-engine-rce) - Written by [Ezequiel Pereira](https://sites.google.com/site/testsitehacking/).

--- a/README-zh.md
+++ b/README-zh.md
@@ -501,7 +501,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 
 - [DRUPAL 7.X SERVICES MODULE UNSERIALIZE() TO RCE](https://www.ambionics.io/blog/drupal-services-module-rce) - Written by [Ambionics Security](https://www.ambionics.io/).
 - [Exploiting Node.js deserialization bug for Remote Code Execution](https://opsecx.com/index.php/2017/02/08/exploiting-node-js-deserialization-bug-for-remote-code-execution/) - Written by [OpSecX](https://opsecx.com/index.php/author/ajinabraham/).
-- [GitHub Enterprise Remote Code Execution](http://exablue.de/blog/2017-03-15-github-enterprise-remote-code-execution.html) - Written by [@iblue](https://github.com/iblue).
+- [GitHub Enterprise Remote Code Execution](https://bounty.github.com/researchers/iblue.html) - Written by [@iblue](https://github.com/iblue).
 - [How I Chained 4 vulnerabilities on GitHub Enterprise, From SSRF Execution Chain to RCE!](http://blog.orange.tw/2017/07/how-i-chained-4-vulnerabilities-on.html) - Written by [Orange](http://blog.orange.tw/).
 - [How we exploited a remote code execution vulnerability in math.js](https://capacitorset.github.io/mathjs/) - Written by [@capacitorset](https://github.com/capacitorset).
 - [PHP垃圾回收机制UAF漏洞分析](http://www.freebuf.com/vuls/122938.html) - Written by [ph1re](http://www.freebuf.com/author/ph1re).

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 
 - [DRUPAL 7.X SERVICES MODULE UNSERIALIZE() TO RCE](https://www.ambionics.io/blog/drupal-services-module-rce) - Written by [Ambionics Security](https://www.ambionics.io/).
 - [Exploiting Node.js deserialization bug for Remote Code Execution](https://opsecx.com/index.php/2017/02/08/exploiting-node-js-deserialization-bug-for-remote-code-execution/) - Written by [OpSecX](https://opsecx.com/index.php/author/ajinabraham/).
-- [GitHub Enterprise Remote Code Execution](http://exablue.de/blog/2017-03-15-github-enterprise-remote-code-execution.html) - Written by [@iblue](https://github.com/iblue).
+- [GitHub Enterprise Remote Code Execution](https://bounty.github.com/researchers/iblue.html) - Written by [@iblue](https://github.com/iblue).
 - [How I Chained 4 vulnerabilities on GitHub Enterprise, From SSRF Execution Chain to RCE!](http://blog.orange.tw/2017/07/how-i-chained-4-vulnerabilities-on.html) - Written by [Orange](http://blog.orange.tw/).
 - [How we exploited a remote code execution vulnerability in math.js](https://capacitorset.github.io/mathjs/) - Written by [@capacitorset](https://github.com/capacitorset).
 - [$36k Google App Engine RCE](https://sites.google.com/site/testsitehacking/-36k-google-app-engine-rce) - Written by [Ezequiel Pereira](https://sites.google.com/site/testsitehacking/).

--- a/data/entries/tricks-rce.yml
+++ b/data/entries/tricks-rce.yml
@@ -35,7 +35,7 @@ entries:
     status: active
     raw_rest: "Written by [OpSecX](https://opsecx.com/index.php/author/ajinabraham/)."
   - id: tricks-rce-github-enterprise-remote-code-execution
-    url: "http://exablue.de/blog/2017-03-15-github-enterprise-remote-code-execution.html"
+    url: "https://bounty.github.com/researchers/iblue.html"
     title: GitHub Enterprise Remote Code Execution
     author:
       name: "@iblue"

--- a/data/index.json
+++ b/data/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-05-28T07:03:52Z",
+  "generated_at": "2026-06-01T14:35:30Z",
   "categories": [
     {
       "key": "digests",
@@ -9307,7 +9307,7 @@
     },
     {
       "id": "tricks-rce-github-enterprise-remote-code-execution",
-      "url": "http://exablue.de/blog/2017-03-15-github-enterprise-remote-code-execution.html",
+      "url": "https://bounty.github.com/researchers/iblue.html",
       "title": "GitHub Enterprise Remote Code Execution",
       "author": {
         "name": "@iblue",


### PR DESCRIPTION
## Summary
- replace the dead exablue.de GitHub Enterprise RCE resource URL with GitHub's live Bug Bounty researcher page for @iblue
- regenerate the README files and data index from the YAML source

## Validation
- old URL returns 404 after redirecting to https://exablue.de/blog/2017-03-15-github-enterprise-remote-code-execution.html
- replacement URL returns 200
- python scripts/generate.py
- python scripts/verify_schema.py
- PYTHONUTF8=1 python scripts/verify_anchors.py
- git diff --check

Fixes #181