### PR TITLE
Fix OWASP Juice Shop repository link

### DIFF
--- a/README-jp.md
+++ b/README-jp.md
@@ -866,7 +866,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 - [SELinux Game](http://selinuxgame.org/) - Learn SELinux by doing. Solve Puzzles, show skillz - Written by [@selinuxgame](https://twitter.com/selinuxgame).
 - [BadLibrary](https://github.com/SecureSkyTechnology/BadLibrary) - Vulnerable web application for training - Written by [@SecureSkyTechnology](https://github.com/SecureSkyTechnology).
 - [Hackxor](http://hackxor.net/) - Realistic web application hacking game - Written by [@albinowax](https://twitter.com/albinowax).
-- [OWASP Juice Shop](https://github.com/bkimminich/juice-shop) - Probably the most modern and sophisticated insecure web application - Written by [@bkimminich](https://github.com/bkimminich) and the [@owasp_juiceshop](https://twitter.com/owasp_juiceshop) team.
+- [OWASP Juice Shop](https://github.com/juice-shop/juice-shop) - Probably the most modern and sophisticated insecure web application - Written by [@bkimminich](https://github.com/bkimminich) and the [@owasp_juiceshop](https://twitter.com/owasp_juiceshop) team.
 - [Portswigger Web Security Academy](https://portswigger.net/web-security) - Free trainings and labs - Written by [PortSwigger](https://portswigger.net/).
 - [OopsSec Store](https://github.com/kOaDT/oss-oopssec-store) - Intentionally vulnerable e-commerce application built with Next.js - Written by [@kOaDT](https://github.com/kOaDT).
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -918,7 +918,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 - [SELinux Game](http://selinuxgame.org/) - Learn SELinux by doing. Solve Puzzles, show skillz - Written by [@selinuxgame](https://twitter.com/selinuxgame).
 - [BadLibrary](https://github.com/SecureSkyTechnology/BadLibrary) - Vulnerable web application for training - Written by [@SecureSkyTechnology](https://github.com/SecureSkyTechnology).
 - [Hackxor](http://hackxor.net/) - Realistic web application hacking game - Written by [@albinowax](https://twitter.com/albinowax).
-- [OWASP Juice Shop](https://github.com/bkimminich/juice-shop) - Probably the most modern and sophisticated insecure web application - Written by [@bkimminich](https://github.com/bkimminich) and the [@owasp_juiceshop](https://twitter.com/owasp_juiceshop) team.
+- [OWASP Juice Shop](https://github.com/juice-shop/juice-shop) - Probably the most modern and sophisticated insecure web application - Written by [@bkimminich](https://github.com/bkimminich) and the [@owasp_juiceshop](https://twitter.com/owasp_juiceshop) team.
 - [Portswigger Web Security Academy](https://portswigger.net/web-security) - Free trainings and labs - Written by [PortSwigger](https://portswigger.net/).
 - [OopsSec Store](https://github.com/kOaDT/oss-oopssec-store) - Intentionally vulnerable e-commerce application built with Next.js - Written by [@kOaDT](https://github.com/kOaDT).
 

--- a/README.md
+++ b/README.md
@@ -866,7 +866,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 - [SELinux Game](http://selinuxgame.org/) - Learn SELinux by doing. Solve Puzzles, show skillz - Written by [@selinuxgame](https://twitter.com/selinuxgame).
 - [BadLibrary](https://github.com/SecureSkyTechnology/BadLibrary) - Vulnerable web application for training - Written by [@SecureSkyTechnology](https://github.com/SecureSkyTechnology).
 - [Hackxor](http://hackxor.net/) - Realistic web application hacking game - Written by [@albinowax](https://twitter.com/albinowax).
-- [OWASP Juice Shop](https://github.com/bkimminich/juice-shop) - Probably the most modern and sophisticated insecure web application - Written by [@bkimminich](https://github.com/bkimminich) and the [@owasp_juiceshop](https://twitter.com/owasp_juiceshop) team.
+- [OWASP Juice Shop](https://github.com/juice-shop/juice-shop) - Probably the most modern and sophisticated insecure web application - Written by [@bkimminich](https://github.com/bkimminich) and the [@owasp_juiceshop](https://twitter.com/owasp_juiceshop) team.
 - [Portswigger Web Security Academy](https://portswigger.net/web-security) - Free trainings and labs - Written by [PortSwigger](https://portswigger.net/).
 - [OopsSec Store](https://github.com/kOaDT/oss-oopssec-store) - Intentionally vulnerable e-commerce application built with Next.js - Written by [@kOaDT](https://github.com/kOaDT).
 

--- a/data/entries/practices-application.yml
+++ b/data/entries/practices-application.yml
@@ -51,7 +51,7 @@ entries:
     status: active
     raw_rest: "Realistic web application hacking game - Written by [@albinowax](https://twitter.com/albinowax)."
   - id: practices-application-owasp-juice-shop
-    url: "https://github.com/bkimminich/juice-shop"
+    url: "https://github.com/juice-shop/juice-shop"
     title: OWASP Juice Shop
     author:
       name: "@bkimminich"

--- a/data/index.json
+++ b/data/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-06-01T14:35:30Z",
+  "generated_at": "2026-06-02T08:03:39Z",
   "categories": [
     {
       "key": "digests",
@@ -5153,7 +5153,7 @@
     },
     {
       "id": "practices-application-owasp-juice-shop",
-      "url": "https://github.com/bkimminich/juice-shop",
+      "url": "https://github.com/juice-shop/juice-shop",
       "title": "OWASP Juice Shop",
       "author": {
         "name": "@bkimminich",


### PR DESCRIPTION
## Summary
- Update the OWASP Juice Shop entry to the current `juice-shop/juice-shop` repository
- Regenerate the README files and `data/index.json` from the structured data

## Verification
- `py scripts\generate.py`
- `py scripts\verify_schema.py`
- `py scripts\verify_anchors.py`
- `git diff --check`
- Confirmed `bkimminich/juice-shop` returns 404 via the GitHub API
- Confirmed `juice-shop/juice-shop` exists via the GitHub API