### PR TITLE
Add OSINT Projects to Reconnaissance (OSINT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,6 +647,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 - [Social Mapper](https://github.com/SpiderLabs/social_mapper) - Social Media Enumeration & Correlation Tool by Jacob Wilkin(Greenwolf) by [@SpiderLabs](https://github.com/SpiderLabs).
 - [Marshall Extensions](https://github.com/bad-antics/marshall-extensions) - OSINT and security extensions for the Marshall privacy browser, providing reconnaissance and security-testing plugins by [@bad-antics](https://github.com/bad-antics).
 - [OpenBuckets](https://openbuckets.io/) - Search engine for misconfigured public cloud storage buckets across any provider.
+- [OSINT Projects](https://osintprojects.com) - Free web toolkit for WHOIS/RDAP, DNS, IP geolocation, SSL certificate inspection and Certificate Transparency subdomain discovery.
 
 <a name="tools-sub-domain-enumeration"></a>
 #### Sub Domain Enumeration

--- a/data/entries/tools-osint.yml
+++ b/data/entries/tools-osint.yml
@@ -383,3 +383,19 @@ entries:
     fingerprint: null
     status: active
     raw_rest: "OSINT and security extensions for the Marshall privacy browser, providing reconnaissance and security-testing plugins by [@bad-antics](https://github.com/bad-antics)."
+  - id: tools-osint-osint-projects
+    url: "https://osintprojects.com"
+    title: OSINT Projects
+    author:
+      name: OSINT Projects
+      url: "https://osintprojects.com"
+    category: tools-osint
+    type: tool
+    languages: [en]
+    difficulty: intro
+    date_added: "2026-07-09"
+    archive_url: null
+    last_checked: null
+    fingerprint: null
+    status: active
+    raw_rest: "Free web toolkit for WHOIS/RDAP, DNS, IP geolocation, SSL certificate inspection and Certificate Transparency subdomain discovery."

--- a/data/index.json
+++ b/data/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-06-26T16:46:36Z",
+  "generated_at": "2026-07-09T05:23:07Z",
   "categories": [
     {
       "key": "digests",
@@ -7511,6 +7511,25 @@
       "difficulty": "intro",
       "date_added": "2026-05-12",
       "archive_url": "https://web.archive.org/web/20260513061543/https://github.com/bad-antics/marshall-extensions",
+      "last_checked": null,
+      "status": "active"
+    },
+    {
+      "id": "tools-osint-osint-projects",
+      "url": "https://osintprojects.com",
+      "title": "OSINT Projects",
+      "author": {
+        "name": "OSINT Projects",
+        "url": "https://osintprojects.com"
+      },
+      "category": "tools-osint",
+      "type": "tool",
+      "languages": [
+        "en"
+      ],
+      "difficulty": "intro",
+      "date_added": "2026-07-09",
+      "archive_url": null,
       "last_checked": null,
       "status": "active"
     },


### PR DESCRIPTION
Adds [OSINT Projects](https://osintprojects.com) — free web toolkit for WHOIS/RDAP, DNS, IP geolocation, SSL certificate inspection and Certificate Transparency subdomain discovery. Useful for the recon phase.