### PR TITLE
Add rqwstr (AI-native HTTP security testing MCP server)

### DIFF
--- a/README-jp.md
+++ b/README-jp.md
@@ -714,6 +714,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 - [grayhatwarfare](https://buckets.grayhatwarfare.com/) - Public buckets by [grayhatwarfare](http://www.grayhatwarfare.com/).
 - [TIDoS-Framework](https://github.com/theInfectedDrake/TIDoS-Framework) - A comprehensive web application audit framework to cover up everything from Reconnaissance and OSINT to Vulnerability Analysis by [@_tID](https://github.com/theInfectedDrake).
 - [numasec](https://github.com/FrancescoStabile/numasec) - AI-driven penetration-testing platform that coordinates 10 agents and 38 vulnerability scanners covering OWASP Top 10, by [@FrancescoStabile](https://github.com/FrancescoStabile).
+- [rqwstr](https://github.com/Kjopstad-IT/rqwstr-mcp) - AI-native HTTP security testing toolkit (MCP server) with low-level control over HTTP/1.1 + HTTP/2 (raw framing, connection pinning) by [Kjøpstad IT](https://rqwstr.com).
 
 <a name="tools-offensive"></a>
 ### Offensive

--- a/README-zh.md
+++ b/README-zh.md
@@ -760,6 +760,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 - [grayhatwarfare](https://buckets.grayhatwarfare.com/) - Public buckets by [grayhatwarfare](http://www.grayhatwarfare.com/).
 - [TIDoS-Framework](https://github.com/theInfectedDrake/TIDoS-Framework) - A comprehensive web application audit framework to cover up everything from Reconnaissance and OSINT to Vulnerability Analysis by [@_tID](https://github.com/theInfectedDrake).
 - [numasec](https://github.com/FrancescoStabile/numasec) - AI-driven penetration-testing platform that coordinates 10 agents and 38 vulnerability scanners covering OWASP Top 10, by [@FrancescoStabile](https://github.com/FrancescoStabile).
+- [rqwstr](https://github.com/Kjopstad-IT/rqwstr-mcp) - AI-native HTTP security testing toolkit (MCP server) with low-level control over HTTP/1.1 + HTTP/2 (raw framing, connection pinning) by [Kjøpstad IT](https://rqwstr.com).
 
 <a name="tools-offensive"></a>
 ### Offensive

--- a/README.md
+++ b/README.md
@@ -701,6 +701,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 - [grayhatwarfare](https://buckets.grayhatwarfare.com/) - Public buckets by [grayhatwarfare](http://www.grayhatwarfare.com/).
 - [TIDoS-Framework](https://github.com/theInfectedDrake/TIDoS-Framework) - A comprehensive web application audit framework to cover up everything from Reconnaissance and OSINT to Vulnerability Analysis by [@_tID](https://github.com/theInfectedDrake).
 - [numasec](https://github.com/FrancescoStabile/numasec) - AI-driven penetration-testing platform that coordinates 10 agents and 38 vulnerability scanners covering OWASP Top 10, by [@FrancescoStabile](https://github.com/FrancescoStabile).
+- [rqwstr](https://github.com/Kjopstad-IT/rqwstr-mcp) - AI-native HTTP security testing toolkit (MCP server) with low-level control over HTTP/1.1 + HTTP/2 (raw framing, connection pinning) by [Kjøpstad IT](https://rqwstr.com).
 
 <a name="tools-offensive"></a>
 ### Offensive

--- a/data/entries/tools-penetration-testing.yml
+++ b/data/entries/tools-penetration-testing.yml
@@ -98,3 +98,19 @@ entries:
     fingerprint: null
     status: active
     raw_rest: "AI-driven penetration-testing platform that coordinates 10 agents and 38 vulnerability scanners covering OWASP Top 10, by [@FrancescoStabile](https://github.com/FrancescoStabile)."
+  - id: tools-penetration-testing-rqwstr
+    url: "https://github.com/Kjopstad-IT/rqwstr-mcp"
+    title: rqwstr
+    author:
+      name: Kjøpstad IT
+      url: "https://rqwstr.com"
+    category: tools-penetration-testing
+    type: tool
+    languages: [en, zh, jp]
+    difficulty: intermediate
+    date_added: "2026-06-17"
+    archive_url: null
+    last_checked: null
+    fingerprint: null
+    status: active
+    raw_rest: "AI-native HTTP security testing toolkit (MCP server) with low-level control over HTTP/1.1 + HTTP/2 (raw framing, connection pinning) by [Kjøpstad IT](https://rqwstr.com)."

--- a/data/index.json
+++ b/data/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-06-03T16:11:57Z",
+  "generated_at": "2026-06-17T15:33:11Z",
   "categories": [
     {
       "key": "digests",
@@ -7732,6 +7732,27 @@
       "difficulty": "intermediate",
       "date_added": "2026-05-14",
       "archive_url": "https://web.archive.org/web/20260514052501/https://github.com/FrancescoStabile/numasec",
+      "last_checked": null,
+      "status": "active"
+    },
+    {
+      "id": "tools-penetration-testing-rqwstr",
+      "url": "https://github.com/Kjopstad-IT/rqwstr-mcp",
+      "title": "rqwstr",
+      "author": {
+        "name": "Kjøpstad IT",
+        "url": "https://rqwstr.com"
+      },
+      "category": "tools-penetration-testing",
+      "type": "tool",
+      "languages": [
+        "en",
+        "zh",
+        "jp"
+      ],
+      "difficulty": "intermediate",
+      "date_added": "2026-06-17",
+      "archive_url": null,
       "last_checked": null,
       "status": "active"
     },


### PR DESCRIPTION
## What this PR adds / changes

Adds rqwstr to Tools > Penetration Testing.

rqwstr is an MCP server that gives an AI agent low-level control over HTTP/1.1 and HTTP/2 (raw framing, connection pinning, intruder-style fuzzing, request racing, OOB detection) on its own Go engine. 17 HTTP tools. The free tier covers the core toolset; a Pro tier adds the heavier offensive tools.

Repo (binaries + docs): https://github.com/Kjopstad-IT/rqwstr-mcp
Site: https://rqwstr.com

## Self-checklist (mirrors RUBRIC.md)

- [x] URL is reachable, returns 2xx, prefers HTTPS, no redirect chain
- [x] Resource has non-trivial content depth (not a marketing or lead-gen page)
- [x] `category` value matches the resource topic
- [x] I searched for similar entries; this adds a distinct angle
- [x] All required schema fields are filled (`id`, `url`, `title`, `category`, `type`, `languages`, `difficulty`, `date_added`, `status`)
- [x] Edited `data/entries/*.yml`, NOT `README*.md` directly (READMEs + index.json regenerated via `scripts/generate.py`)

## Justification (1-2 sentences)

rqwstr fills a gap in the Penetration Testing list: an MCP server that exposes raw HTTP/1.1 and HTTP/2 framing control to AI agents, distinct from the GUI/CLI tools currently listed.