### PR TITLE
Add SaaSFort (free external NIS2/security posture scanner)

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,6 +660,7 @@ If you enjoy this awesome list and would like to support it, check out my [Patre
 - [JoomlaScan](https://github.com/drego85/JoomlaScan) - Free software to find the components installed in Joomla CMS, built out of the ashes of Joomscan by [@drego85](https://github.com/drego85).
 - [WAScan](https://github.com/m4ll0k/WAScan) - Is an open source web application security scanner that uses "black-box" method, created by [@m4ll0k](https://github.com/m4ll0k).
 - [Nuclei](https://github.com/projectdiscovery/nuclei) - Nuclei is a fast tool for configurable targeted scanning based on templates offering massive extensibility and ease of use by [@projectdiscovery](https://github.com/projectdiscovery).
+- [SaaSFort](https://saasfort.com/scan) - Free 60-second external NIS2 / security posture scan, A-F grade, no signup required.
 
 <a name="tools-penetration-testing"></a>
 ### Penetration Testing


### PR DESCRIPTION
Adding SaaSFort under the scanning tools.

It runs about 60 external checks against a public domain (TLS, DNS, security headers, common OWASP-style web exposures) and maps results to NIS2 Article 21 and ISO 27001 Annex A, returning an A-F grade with the per-check breakdown. The scan is free and needs no signup.

I use it for a quick external-posture read before audits and security questionnaires, so it seemed like a useful addition here. Link: https://saasfort.com/scan