### PR TITLE
Add ARS3NAL - offline pentest & bug-bounty arsenal

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,6 +703,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 - [grayhatwarfare](https://buckets.grayhatwarfare.com/) - Public buckets by [grayhatwarfare](http://www.grayhatwarfare.com/).
 - [TIDoS-Framework](https://github.com/theInfectedDrake/TIDoS-Framework) - A comprehensive web application audit framework to cover up everything from Reconnaissance and OSINT to Vulnerability Analysis by [@_tID](https://github.com/theInfectedDrake).
 - [numasec](https://github.com/FrancescoStabile/numasec) - AI-driven penetration-testing platform that coordinates 10 agents and 38 vulnerability scanners covering OWASP Top 10, by [@FrancescoStabile](https://github.com/FrancescoStabile).
+- [ARS3NAL](https://github.com/inflictx/Arsenal) - Offline-first, self-hosted pentest & bug-bounty arsenal - searchable payloads, a click-to-build command generator, GTFOBins, wordlists, an embedded CyberChef, reverse shells and per-vulnerability checklists, with a live static demo - by [@inflictx](https://github.com/inflictx).
 - [Darkmoon](https://github.com/ASCIT31/Dark-Moon) - Open source autonomous AI penetration testing platform that orchestrates 80+ offensive tools via Markdown playbooks and MCP across web, cloud, Active Directory and Kubernetes, with an evidence trail per finding by [@ASCIT31](https://github.com/ASCIT31).
 
 <a name="tools-offensive"></a>

--- a/data/entries/tools-penetration-testing.yml
+++ b/data/entries/tools-penetration-testing.yml
@@ -114,3 +114,19 @@ entries:
     fingerprint: null
     status: active
     raw_rest: "Open source autonomous AI penetration testing platform that orchestrates 80+ offensive tools via Markdown playbooks and MCP across web, cloud, Active Directory and Kubernetes, with an evidence trail per finding by [@ASCIT31](https://github.com/ASCIT31)."
+  - id: tools-penetration-testing-ars3nal
+    url: "https://github.com/inflictx/Arsenal"
+    title: ARS3NAL
+    author:
+      name: "@inflictx"
+      url: "https://github.com/inflictx"
+    category: tools-penetration-testing
+    type: tool
+    languages: [en]
+    difficulty: intermediate
+    date_added: "2026-06-24"
+    archive_url: null
+    last_checked: null
+    fingerprint: null
+    status: active
+    raw_rest: "Offline-first, self-hosted pentest & bug-bounty arsenal - searchable payloads, a click-to-build command generator, GTFOBins, wordlists, an embedded CyberChef, reverse shells and per-vulnerability checklists, with a live static demo - by [@inflictx](https://github.com/inflictx)."

--- a/data/index.json
+++ b/data/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-07-09T06:30:25Z",
+  "generated_at": "2026-07-09T10:58:41Z",
   "categories": [
     {
       "key": "digests",
@@ -7769,6 +7769,25 @@
       ],
       "difficulty": "intermediate",
       "date_added": "2026-07-09",
+      "archive_url": null,
+      "last_checked": null,
+      "status": "active"
+    },
+    {
+      "id": "tools-penetration-testing-ars3nal",
+      "url": "https://github.com/inflictx/Arsenal",
+      "title": "ARS3NAL",
+      "author": {
+        "name": "@inflictx",
+        "url": "https://github.com/inflictx"
+      },
+      "category": "tools-penetration-testing",
+      "type": "tool",
+      "languages": [
+        "en"
+      ],
+      "difficulty": "intermediate",
+      "date_added": "2026-06-24",
       "archive_url": null,
       "last_checked": null,
       "status": "active"


### PR DESCRIPTION
Adds **ARS3NAL** to the list.

ARS3NAL is an offline-first, searchable arsenal for pentesting and bug bounty: ~1500 payloads, a click-to-build command generator, GTFOBins, a wordlists reference, an embedded CyberChef, a reverse-shell generator, 70 interactive checklists and an engagement/findings tracker. It is a self-hosted web app and also ships a static live demo. Open-source, GPL-3.0, bilingual EN/RU.

- Repo: https://github.com/inflictx/Arsenal
- Live demo: https://inflictx.github.io/Arsenal/

Added as a YAML entry in `data/entries/digests.yml` (per CONTRIBUTING the README is generated, not hand-edited). ARS3NAL bundles ~1500 payloads, meeting the comprehensive-payload-list bar.