### PR TITLE
Add Vigolium scanner to the Scanning tools list

### DIFF
--- a/README-jp.md
+++ b/README-jp.md
@@ -699,6 +699,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 - [wpscan](https://github.com/wpscanteam/wpscan) - WPScan is a black box WordPress vulnerability scanner by [@wpscanteam](https://github.com/wpscanteam).
 - [WAScan](https://github.com/m4ll0k/WAScan) - Is an open source web application security scanner that uses "black-box" method, created by [@m4ll0k](https://github.com/m4ll0k).
 - [Nuclei](https://github.com/projectdiscovery/nuclei) - Nuclei is a fast tool for configurable targeted scanning based on templates offering massive extensibility and ease of use by [@projectdiscovery](https://github.com/projectdiscovery).
+- [Vigolium](https://github.com/vigolium/vigolium) - High-fidelity vulnerability scanner fusing agentic AI with native speed, modularity, and precision, maintained by [@j3ssie](https://github.com/j3ssie).
 - [ZAP by Checkmarx](https://zaproxy.org) - Open-source web application security scanner maintained by the ZAP Core Team.
 - [Fray](https://github.com/dalisecurity/fray) - Open-source WAF bypass and security-testing toolkit with 6,300+ payloads across OWASP categories, AI-assisted evasion engine, 27-check reconnaissance pipeline, and OWASP hardening audit, by [@dalisecurity](https://github.com/dalisecurity).
 - [Trust Scan](https://github.com/undeadlist/trust-scan) - URL security scanner combining threat intelligence (URLhaus, PhishTank, Spamhaus) with 40+ scam and phishing pattern detection by [@undeadlist](https://github.com/undeadlist).

--- a/README-zh.md
+++ b/README-zh.md
@@ -745,6 +745,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 - [wpscan](https://github.com/wpscanteam/wpscan) - WPScan is a black box WordPress vulnerability scanner by [@wpscanteam](https://github.com/wpscanteam).
 - [WAScan](https://github.com/m4ll0k/WAScan) - Is an open source web application security scanner that uses "black-box" method, created by [@m4ll0k](https://github.com/m4ll0k).
 - [Nuclei](https://github.com/projectdiscovery/nuclei) - Nuclei is a fast tool for configurable targeted scanning based on templates offering massive extensibility and ease of use by [@projectdiscovery](https://github.com/projectdiscovery).
+- [Vigolium](https://github.com/vigolium/vigolium) - High-fidelity vulnerability scanner fusing agentic AI with native speed, modularity, and precision, maintained by [@j3ssie](https://github.com/j3ssie).
 - [ZAP by Checkmarx](https://zaproxy.org) - Open-source web application security scanner maintained by the ZAP Core Team.
 - [Fray](https://github.com/dalisecurity/fray) - Open-source WAF bypass and security-testing toolkit with 6,300+ payloads across OWASP categories, AI-assisted evasion engine, 27-check reconnaissance pipeline, and OWASP hardening audit, by [@dalisecurity](https://github.com/dalisecurity).
 - [Trust Scan](https://github.com/undeadlist/trust-scan) - URL security scanner combining threat intelligence (URLhaus, PhishTank, Spamhaus) with 40+ scam and phishing pattern detection by [@undeadlist](https://github.com/undeadlist).

--- a/README.md
+++ b/README.md
@@ -686,6 +686,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 - [wpscan](https://github.com/wpscanteam/wpscan) - WPScan is a black box WordPress vulnerability scanner by [@wpscanteam](https://github.com/wpscanteam).
 - [WAScan](https://github.com/m4ll0k/WAScan) - Is an open source web application security scanner that uses "black-box" method, created by [@m4ll0k](https://github.com/m4ll0k).
 - [Nuclei](https://github.com/projectdiscovery/nuclei) - Nuclei is a fast tool for configurable targeted scanning based on templates offering massive extensibility and ease of use by [@projectdiscovery](https://github.com/projectdiscovery).
+- [Vigolium](https://github.com/vigolium/vigolium) - High-fidelity vulnerability scanner fusing agentic AI with native speed, modularity, and precision, maintained by [@j3ssie](https://github.com/j3ssie).
 - [ZAP by Checkmarx](https://zaproxy.org) - Open-source web application security scanner maintained by the ZAP Core Team.
 - [Fray](https://github.com/dalisecurity/fray) - Open-source WAF bypass and security-testing toolkit with 6,300+ payloads across OWASP categories, AI-assisted evasion engine, 27-check reconnaissance pipeline, and OWASP hardening audit, by [@dalisecurity](https://github.com/dalisecurity).
 - [Trust Scan](https://github.com/undeadlist/trust-scan) - URL security scanner combining threat intelligence (URLhaus, PhishTank, Spamhaus) with 40+ scam and phishing pattern detection by [@undeadlist](https://github.com/undeadlist).

--- a/data/entries/tools-scanning.yml
+++ b/data/entries/tools-scanning.yml
@@ -82,6 +82,22 @@ entries:
     fingerprint: null
     status: active
     raw_rest: "Open-source web application security scanner maintained by the ZAP Core Team."
+  - id: tools-scanning-vigolium
+    url: "https://github.com/vigolium/vigolium"
+    title: Vigolium
+    author:
+      name: "@j3ssie"
+      url: "https://github.com/j3ssie"
+    category: tools-scanning
+    type: tool
+    languages: [en, zh, jp]
+    difficulty: intermediate
+    date_added: "2026-05-11"
+    archive_url: null
+    last_checked: null
+    fingerprint: null
+    status: active
+    raw_rest: "High-fidelity vulnerability scanner fusing agentic AI with native speed, modularity, and precision, maintained by [@j3ssie](https://github.com/j3ssie)."
   - id: tools-scanning-trust-scan
     url: "https://github.com/undeadlist/trust-scan"
     title: Trust Scan

--- a/data/index.json
+++ b/data/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-06-03T16:11:57Z",
+  "generated_at": "2026-06-26T16:46:36Z",
   "categories": [
     {
       "key": "digests",
@@ -8130,6 +8130,27 @@
       "difficulty": "intro",
       "date_added": "2026-05-11",
       "archive_url": "https://web.archive.org/web/20260511151417/https://www.zaproxy.org/",
+      "last_checked": null,
+      "status": "active"
+    },
+    {
+      "id": "tools-scanning-vigolium",
+      "url": "https://github.com/vigolium/vigolium",
+      "title": "Vigolium",
+      "author": {
+        "name": "@j3ssie",
+        "url": "https://github.com/j3ssie"
+      },
+      "category": "tools-scanning",
+      "type": "tool",
+      "languages": [
+        "en",
+        "zh",
+        "jp"
+      ],
+      "difficulty": "intermediate",
+      "date_added": "2026-05-11",
+      "archive_url": null,
       "last_checked": null,
       "status": "active"
     },


### PR DESCRIPTION
> Re-opening #191 (original fork was accidentally deleted).

Added [Vigolium](https://github.com/vigolium/vigolium) - High-fidelity vulnerability scanner fusing agentic AI with native speed, modularity, and precision

## Self-checklist (mirrors RUBRIC.md)

- [x] URL is reachable, returns 2xx, prefers HTTPS, no redirect chain
- [x] Resource has non-trivial content depth (not a marketing or lead-gen page)
- [x] `category` value matches the resource topic
- [x] I searched for similar entries; this adds a distinct angle
- [x] All required schema fields are filled (`id`, `url`, `title`, `category`, `type`, `languages`, `difficulty`, `date_added`, `status`)
- [x] Edited `data/entries/*.yml`, NOT `README*.md` directly (READMEs regenerated via `scripts/generate.py`)

## Justification

Vigolium is an agentic-AI vulnerability scanner emphasizing native speed and modular precision — a distinct angle not covered by existing entries in the Scanning section. Added to `data/entries/tools-scanning.yml` and the three READMEs + `data/index.json` were regenerated with `scripts/generate.py`; `verify_schema.py` and `verify_anchors.py` both pass.
