### PR TITLE
Add Penetrify to tools-penetration-testing

### DIFF
--- a/data/entries/tools-penetration-testing.yml
+++ b/data/entries/tools-penetration-testing.yml
@@ -98,3 +98,19 @@ entries:
     fingerprint: null
     status: active
     raw_rest: "AI-driven penetration-testing platform that coordinates 10 agents and 38 vulnerability scanners covering OWASP Top 10, by [@FrancescoStabile](https://github.com/FrancescoStabile)."
+  - id: tools-penetration-testing-penetrify
+    url: "https://www.penetrify.cloud/"
+    title: Penetrify
+    author:
+      name: Penetrify
+      url: "https://www.penetrify.cloud/"
+    category: tools-penetration-testing
+    type: tool
+    languages: [en, zh, jp]
+    difficulty: intermediate
+    date_added: "2026-06-30"
+    archive_url: null
+    last_checked: null
+    fingerprint: null
+    status: active
+    raw_rest: "Autonomous AI penetration testing platform that exploits and chains vulnerabilities in web applications and APIs, with CI/CD integration, by [Penetrify](https://www.penetrify.cloud/)."


### PR DESCRIPTION
Adds Penetrify to the tools-penetration-testing category.

What it is: an autonomous AI penetration testing platform for web applications and APIs - it explores the attack surface, exploits and chains vulnerabilities (authorization/IDOR, business logic, OWASP Top 10), and integrates with CI/CD. Hosted SaaS, commercial.

How this was added (YAML-first): added a single entry to data/entries/tools-penetration-testing.yml, following the existing schema; README files are left untouched so the generated output stays in sync with the data model.

Rubric notes:
 - Category fit: a penetration-testing platform in tools-penetration-testing, alongside commercial entries like Burp Suite.
 - Reachability: live at https://www.penetrify.cloud/.
 - Dedup: not currently listed.
 - Format: matches the entry schema (id, url, title, author, category, type, languages, difficulty, date_added, raw_rest).

Disclosure: I'm affiliated with Penetrify. Kept the entry factual to match the list's style - happy to adjust wording, difficulty, or category if you'd prefer.