### PR TITLE
Add SecureMonk to Scanning tools

### DIFF
--- a/data/entries/tools-scanning.yml
+++ b/data/entries/tools-scanning.yml
@@ -162,3 +162,19 @@ entries:
     fingerprint: null
     status: active
     raw_rest: "Free online collection of 29 client-side web security tools: web auditor, JWT attacker/decoder, CVE search, CSP evaluator, email security checker (SPF/DKIM/DMARC), subdomain scanner, and more. 100% client-side, privacy-first, open source by [@ReplikanteK](https://github.com/ReplikanteK)."
+  - id: tools-scanning-securemonk
+    url: "https://securemonk.io"
+    title: SecureMonk
+    author:
+      name: "SecureMonk"
+      url: "https://securemonk.io"
+    category: tools-scanning
+    type: tool
+    languages: [en]
+    difficulty: intro
+    date_added: "2026-07-15"
+    archive_url: null
+    last_checked: null
+    fingerprint: null
+    status: active
+    raw_rest: "Free scanner for TLS/SSL configuration and HTTP security headers in one report, with CVE-based vulnerability detection and an AI security assistant grounded in NVD/CISA-KEV/OWASP data. No signup."


### PR DESCRIPTION
Adds [SecureMonk](https://securemonk.io) to `data/entries/tools-scanning.yml`, following the documented YAML-first schema (matching the existing `SecuriTool` entry's shape).

**What it fills:** the section already lists `ssltest` (Qualys SSL Labs, under Fuzzing) and general-purpose scanners, but nothing that combines TLS/SSL configuration analysis with HTTP security header analysis in a single report. SecureMonk does both, plus CVE-based vulnerability detection and an AI assistant for follow-up questions. Free, no signup.

Note: I only edited the YAML source, not the generated `README*.md` files, per the CONTRIBUTING.md guidance that those are auto-generated — leaving regeneration to CI/maintainer review rather than running scripts from the repo locally.