### PR TITLE
Add jwt-auditor to JWT section

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 ### JWT
 
 - [Hardcoded secrets, unverified tokens, and other common JWT mistakes](https://r2c.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/) - Written by [@ermil0v](https://twitter.com/ermil0v).
+- [jwt-auditor](https://github.com/mohelobeid/jwt-auditor) - Offline CLI that decodes and audits JSON Web Tokens for the alg:none downgrade, weak HMAC secrets, and the RS256 to HS256 confusion attack. Written by [@mohelobeid](https://github.com/mohelobeid).
 
 ## Evasions
 


### PR DESCRIPTION
Adds jwt-auditor to the JWT section.

- Reachable: https://github.com/mohelobeid/jwt-auditor (public, HTTPS, returns 200)
- Solves a real problem: an offline CLI that decodes JWTs and audits them for the alg:none downgrade, weak HMAC secrets, and the RS256 to HS256 confusion attack, plus expiry and sensitive-claim checks.
- Depth: a working tool with a full learn/ folder (concepts, architecture, implementation walkthrough) and 60 tests, not a marketing page.
- Category fit: it is a JWT security tool, placed in the JWT section.
- No duplicate: checked the JWT section, no existing JWT tool entry.