### PR TITLE
Add OAuth Verification Path Map to the OAuth section

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 
 - [What is going on with OAuth 2.0? And why you should not use it for authentication.](https://medium.com/securing/what-is-going-on-with-oauth-2-0-and-why-you-should-not-use-it-for-authentication-5f47597b2611) - Written by [@damianrusinek](https://medium.com/@damianrusinek).
 - [Introduction to OAuth 2.0 and OpenID Connect](https://pragmaticwebsecurity.com/courses/introduction-oauth-oidc.html) - Written by [@PhilippeDeRyck](https://twitter.com/PhilippeDeRyck).
+- [OAuth Verification Path Map](https://mordiaky.github.io/oauth-preflight/) - A free, static, client-side quiz that classifies which Google OAuth app-verification path an app is likely on (no verification / brand review / restricted-scope CASA security assessment), with a dated official Google or App Defense Alliance source for every rule.
 
 <a name="jwt"></a>
 ### JWT

--- a/data/entries/oauth.yml
+++ b/data/entries/oauth.yml
@@ -66,3 +66,19 @@ entries:
     fingerprint: null
     status: active
     raw_rest: "Written by [@PhilippeDeRyck](https://twitter.com/PhilippeDeRyck)."
+  - id: oauth-verification-path-map
+    url: "https://mordiaky.github.io/oauth-preflight/"
+    title: OAuth Verification Path Map
+    author:
+      name: "mordiaky"
+      url: "https://github.com/mordiaky"
+    category: oauth
+    type: tool
+    languages: [en]
+    difficulty: intro
+    date_added: "2026-07-19"
+    archive_url: null
+    last_checked: null
+    fingerprint: null
+    status: active
+    raw_rest: "A free, static, client-side quiz that classifies which Google OAuth app-verification path an app is likely on (no verification / brand review / restricted-scope CASA security assessment), with a dated official Google or App Defense Alliance source for every rule"

--- a/data/index.json
+++ b/data/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-07-18T15:08:54Z",
+  "generated_at": "2026-07-19T16:52:05Z",
   "categories": [
     {
       "key": "digests",
@@ -4727,6 +4727,25 @@
       ],
       "difficulty": "intermediate",
       "date_added": "2020-05-12",
+      "archive_url": null,
+      "last_checked": null,
+      "status": "active"
+    },
+    {
+      "id": "oauth-verification-path-map",
+      "url": "https://mordiaky.github.io/oauth-preflight/",
+      "title": "OAuth Verification Path Map",
+      "author": {
+        "name": "mordiaky",
+        "url": "https://github.com/mordiaky"
+      },
+      "category": "oauth",
+      "type": "tool",
+      "languages": [
+        "en"
+      ],
+      "difficulty": "intro",
+      "date_added": "2026-07-19",
       "archive_url": null,
       "last_checked": null,
       "status": "active"


### PR DESCRIPTION
Adds a `tool`-type entry to `data/entries/oauth.yml`: [OAuth Verification Path Map](https://mordiaky.github.io/oauth-preflight/).

**Gap it fills:** every existing OAuth entry here is an explainer article about how OAuth 2.0 works or its pitfalls. This is a practical companion — a free, static, client-side quiz that tells a developer which Google-specific verification path they're on (no verification needed / brand review / a restricted-scope CASA security assessment) and what that path actually requires, before they read the theory articles or talk to a paid assessor.

**Angle:** every rule cites a dated official Google or App Defense Alliance source, never a vendor marketing page — including a note that the ADA's CASA tiering model itself changed within the last month (AL1/AL2 replacing the older Tier 1/2/3 framing many assessor vendors still use). Full source research is public in the linked repo. MIT licensed, zero dependencies, nothing sent off the page.

`difficulty: intro` since it's meant as the first practical step, ahead of the more advanced OAuth theory already in this section. `python3 scripts/verify_schema.py` and `scripts/generate.py` both run clean; diff is scoped to `data/entries/oauth.yml`, `data/index.json`, and the regenerated `README.md` (entry is `languages: [en]` only, so the zh/jp READMEs are untouched).