### PR TITLE
Add wp2shell-detect (WordPress core pre-auth RCE detector)

### DIFF
--- a/data/entries/tools-scanning.yml
+++ b/data/entries/tools-scanning.yml
@@ -34,6 +34,22 @@ entries:
     fingerprint: null
     status: active
     raw_rest: "WPScan is a black box WordPress vulnerability scanner by [@wpscanteam](https://github.com/wpscanteam)."
+  - id: tools-scanning-wp2shell-detect
+    url: "https://github.com/own2pwn-fr/wp2shell-detect"
+    title: wp2shell-detect
+    author:
+      name: "@own2pwn-fr"
+      url: "https://github.com/own2pwn-fr"
+    category: tools-scanning
+    type: tool
+    languages: [en]
+    difficulty: intermediate
+    date_added: "2026-07-19"
+    archive_url: null
+    last_checked: null
+    fingerprint: null
+    status: active
+    raw_rest: "Blackbox, non-intrusive detector for the wp2shell pre-auth RCE chain in WordPress core (CVE-2026-63030 / CVE-2026-60137); fingerprints the core version from public sources and flags vulnerable ranges without ever exploiting the flaw."
   - id: tools-scanning-wascan
     url: "https://github.com/m4ll0k/WAScan"
     title: WAScan


### PR DESCRIPTION
Adds **wp2shell-detect**, a read-only detector for the WordPress core pre-auth RCE chain disclosed on 2026-07-17 (CVE-2026-63030 route confusion in the REST batch endpoint + CVE-2026-60137 SQL injection in `WP_Query`).

It fingerprints the WordPress core version from several public, read-only sources and flags installs that fall in the known-vulnerable ranges. It does **not** exploit anything: every request is one a normal crawler could send.

- Repo: https://github.com/own2pwn-fr/wp2shell-detect
- MIT license, single Python file, zero dependencies
- Disclosure: 2026-07-17 (Searchlight Cyber / Assetnote)

Added as a YAML block in `data/entries/tools-scanning.yml` (Scanning category), right after the `wpscan` entry, matching the existing schema. No duplicate detector for this chain currently listed.
