### PR TITLE
Add admintoolkit.io to Scanning tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,6 +693,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 - [Trust Scan](https://github.com/undeadlist/trust-scan) - URL security scanner combining threat intelligence (URLhaus, PhishTank, Spamhaus) with 40+ scam and phishing pattern detection by [@undeadlist](https://github.com/undeadlist).
 - [ZeroTrust](https://github.com/sattyamjjain/zerotrust) - Privacy-first Chrome extension that analyzes website security locally with on-device AI (WebGPU), producing trust scores from HTTPS, phishing, malicious-script, and cookie-compliance signals, by [@sattyamjjain](https://github.com/sattyamjjain).
 - [SecuriTool](https://securitool.js.org/) - Free online collection of 29 client-side web security tools: web auditor, JWT attacker/decoder, CVE search, CSP evaluator, email security checker (SPF/DKIM/DMARC), subdomain scanner, and more. 100% client-side, privacy-first, open source by [@ReplikanteK](https://github.com/ReplikanteK).
+- [admintoolkit.io](https://admintoolkit.io/) - 24 read-only browser-based diagnostics for DNSSEC, DANE/TLSA, SPF/DKIM/DMARC, BIMI, MTA-STS, TLS-RPT, SMTP TLS, HTTP headers, TLS configuration, and security.txt validation.
 
 <a name="tools-penetration-testing"></a>
 ### Penetration Testing

--- a/data/entries/tools-scanning.yml
+++ b/data/entries/tools-scanning.yml
@@ -162,3 +162,19 @@ entries:
     fingerprint: null
     status: active
     raw_rest: "Free online collection of 29 client-side web security tools: web auditor, JWT attacker/decoder, CVE search, CSP evaluator, email security checker (SPF/DKIM/DMARC), subdomain scanner, and more. 100% client-side, privacy-first, open source by [@ReplikanteK](https://github.com/ReplikanteK)."
+  - id: tools-scanning-admintoolkit-io
+    url: "https://admintoolkit.io/"
+    title: admintoolkit.io
+    author:
+      name: admintoolkit.io
+      url: "https://admintoolkit.io/"
+    category: tools-scanning
+    type: tool
+    languages: [en]
+    difficulty: intro
+    date_added: "2026-07-20"
+    archive_url: null
+    last_checked: null
+    fingerprint: null
+    status: active
+    raw_rest: "24 read-only browser-based diagnostics for DNSSEC, DANE/TLSA, SPF/DKIM/DMARC, BIMI, MTA-STS, TLS-RPT, SMTP TLS, HTTP headers, TLS configuration, and security.txt validation."

--- a/data/index.json
+++ b/data/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-07-18T15:08:54Z",
+  "generated_at": "2026-07-20T11:27:24Z",
   "categories": [
     {
       "key": "digests",
@@ -8292,6 +8292,25 @@
       "difficulty": "intro",
       "date_added": "2026-05-28",
       "archive_url": "https://web.archive.org/web/20260531111954/https://securitool.js.org/",
+      "last_checked": null,
+      "status": "active"
+    },
+    {
+      "id": "tools-scanning-admintoolkit-io",
+      "url": "https://admintoolkit.io/",
+      "title": "admintoolkit.io",
+      "author": {
+        "name": "admintoolkit.io",
+        "url": "https://admintoolkit.io/"
+      },
+      "category": "tools-scanning",
+      "type": "tool",
+      "languages": [
+        "en"
+      ],
+      "difficulty": "intro",
+      "date_added": "2026-07-20",
+      "archive_url": null,
       "last_checked": null,
       "status": "active"
     },


### PR DESCRIPTION
## What this PR adds / changes

Adds [admintoolkit.io](https://admintoolkit.io/) to `Tools > Scanning`.

## Self-checklist (mirrors RUBRIC.md)

- [x] URL is reachable, returns 2xx, prefers HTTPS, no redirect chain
- [x] Resource has non-trivial content depth (not a marketing or lead-gen page)
- [x] `category` value matches the resource topic
- [x] I searched for similar entries; this adds a distinct angle
- [x] All required schema fields are filled (`id`, `url`, `title`, `category`, `type`, `languages`, `difficulty`, `date_added`, `status`)
- [x] Edited `data/entries/*.yml`, NOT `README*.md` directly

## Justification (1–2 sentences)

admintoolkit.io provides 24 read-only browser-based diagnostics for DNSSEC, DANE/TLSA, mail authentication and transport policies, SMTP TLS, HTTP headers, TLS configuration, and security.txt. Unlike the existing general-purpose security-tool suite, it focuses on infrastructure and standards validation with explicit live checks and structured results.
