### PR TITLE
Add "State of TLS on the public web" to SSL/TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 
 - [SSL & TLS Penetration Testing](https://www.aptive.co.uk/blog/tls-ssl-security-testing/) - Written by [APTIVE](https://www.aptive.co.uk/).
 - [Practical introduction to SSL/TLS](https://github.com/Hakky54/mutual-tls-ssl) - Written by [@Hakky54](https://github.com/Hakky54).
+- [State of TLS on the public web](https://securemonk.io/insights/state-of-tls) - Live-data research across thousands of scanned hosts: protocol adoption, the TLS-versus-headers maturity gap, ECDSA drawing even with RSA, certificate lifetimes against the CA/B Forum 47-day schedule, and the end of OCSP stapling. Figures recompute from the scan corpus on each load.
 
 <a name="webmail"></a>
 ### Webmail

--- a/data/entries/ssl-tls.yml
+++ b/data/entries/ssl-tls.yml
@@ -34,3 +34,19 @@ entries:
     fingerprint: null
     status: active
     raw_rest: "Written by [@Hakky54](https://github.com/Hakky54)."
+  - id: ssl-tls-state-of-tls-on-the-public-web
+    url: "https://securemonk.io/insights/state-of-tls"
+    title: State of TLS on the public web
+    author:
+      name: SecureMonk
+      url: "https://securemonk.io"
+    category: ssl-tls
+    type: article
+    languages: [en]
+    difficulty: intro
+    date_added: "2026-07-21"
+    archive_url: null
+    last_checked: null
+    fingerprint: null
+    status: active
+    raw_rest: "Live-data research across thousands of scanned hosts: protocol adoption, the TLS-versus-headers maturity gap, ECDSA drawing even with RSA, certificate lifetimes against the CA/B Forum 47-day schedule, and the end of OCSP stapling. Figures recompute from the scan corpus on each load."

--- a/data/index.json
+++ b/data/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-07-26T07:16:41Z",
+  "generated_at": "2026-07-26T07:17:22Z",
   "categories": [
     {
       "key": "digests",
@@ -6081,6 +6081,25 @@
       ],
       "difficulty": "intermediate",
       "date_added": "2020-05-05",
+      "archive_url": null,
+      "last_checked": null,
+      "status": "active"
+    },
+    {
+      "id": "ssl-tls-state-of-tls-on-the-public-web",
+      "url": "https://securemonk.io/insights/state-of-tls",
+      "title": "State of TLS on the public web",
+      "author": {
+        "name": "SecureMonk",
+        "url": "https://securemonk.io"
+      },
+      "category": "ssl-tls",
+      "type": "article",
+      "languages": [
+        "en"
+      ],
+      "difficulty": "intro",
+      "date_added": "2026-07-21",
       "archive_url": null,
       "last_checked": null,
       "status": "active"


### PR DESCRIPTION
Follows up on #200, where @qazbnm456 suggested that "a piece like 'State of TLS on the public web' is exactly the kind of original, verifiable content this list takes, and an article entry tends to clear the bar more easily than the scanner listing itself."

This adds that article as an `ssl-tls` entry. Since #200 was closed, the piece was substantially expanded (2026-07-20): live aggregates recomputed per load from the scan corpus, the TLS-versus-headers maturity gap, certificate-lifetime analysis against CA/B Forum ballot SC-081v3, an OCSP stapling post-mortem anchored on Let's Encrypt's August 2025 shutdown, and a Sources section (RFC 8996, RFC 8446, SC-081v3, Let's Encrypt announcements). Methodology and its limits (self-selected sample) are stated on the page.

Per CONTRIBUTING.md the READMEs are generated, so this PR edits only the YAML source (validated with PyYAML); leaving regeneration to CI/maintainer review. One entry, one PR.