### PR TITLE
Add Poszo Next.js security headers starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -784,6 +784,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 - [CrowdSec](https://www.crowdsec.net/) - Open-source collaborative IPS written in Go that analyzes visitor behavior and shares threat signals across a community of operators, maintained by [CrowdSec](https://github.com/crowdsecurity).
 - [Laravel CSP Generator](https://csp-generator.shakiltech.com) - Interactive Content Security Policy builder for Laravel that outputs ready-to-use PHP middleware with nonce support and violation reporting, by [@itxshakil](https://github.com/itxshakil).
 - [verifyfetch](https://github.com/hamzaydia/verifyfetch) - Browser-side integrity verification and resumable downloads for large files using SRI hashes, defending against CDN compromise and supply-chain attacks, by [@hamzaydia](https://github.com/hamzaydia).
+- [Poszo Next.js Security Headers Starter](https://github.com/poszothebuilder/poszo-nextjs-security-headers) - Dependency-free Next.js response-header starter with a production verifier, report-only CSP example, validation commands, rollback guidance, and documented limitations, maintained by [Poszo](https://github.com/poszothebuilder).
 
 <a name="tools-proxy"></a>
 ### Proxy

--- a/data/entries/tools-preventing.yml
+++ b/data/entries/tools-preventing.yml
@@ -194,3 +194,19 @@ entries:
     fingerprint: null
     status: active
     raw_rest: "Open-source collaborative IPS written in Go that analyzes visitor behavior and shares threat signals across a community of operators, maintained by [CrowdSec](https://github.com/crowdsecurity)."
+  - id: tools-preventing-poszo-nextjs-security-headers
+    url: "https://github.com/poszothebuilder/poszo-nextjs-security-headers"
+    title: Poszo Next.js Security Headers Starter
+    author:
+      name: Poszo
+      url: "https://github.com/poszothebuilder"
+    category: tools-preventing
+    type: tool
+    languages: [en]
+    difficulty: intro
+    date_added: "2026-07-24"
+    archive_url: null
+    last_checked: null
+    fingerprint: null
+    status: active
+    raw_rest: "Dependency-free Next.js response-header starter with a production verifier, report-only CSP example, validation commands, rollback guidance, and documented limitations, maintained by [Poszo](https://github.com/poszothebuilder)."

--- a/data/index.json
+++ b/data/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-07-18T15:08:54Z",
+  "generated_at": "2026-07-24T18:00:01Z",
   "categories": [
     {
       "key": "digests",
@@ -8040,6 +8040,25 @@
       "difficulty": "intro",
       "date_added": "2026-05-14",
       "archive_url": "https://web.archive.org/web/20260603160905/https://www.crowdsec.net/",
+      "last_checked": null,
+      "status": "active"
+    },
+    {
+      "id": "tools-preventing-poszo-nextjs-security-headers",
+      "url": "https://github.com/poszothebuilder/poszo-nextjs-security-headers",
+      "title": "Poszo Next.js Security Headers Starter",
+      "author": {
+        "name": "Poszo",
+        "url": "https://github.com/poszothebuilder"
+      },
+      "category": "tools-preventing",
+      "type": "tool",
+      "languages": [
+        "en"
+      ],
+      "difficulty": "intro",
+      "date_added": "2026-07-24",
+      "archive_url": null,
       "last_checked": null,
       "status": "active"
     },


### PR DESCRIPTION
## Why

This adds a framework-specific preventing resource for Next.js deployments. The repository includes copyable response-header configuration, a report-only CSP example, a production verifier, validation commands, rollback guidance, and explicit limitations. It complements the existing general CSP tools with an implementation-focused Next.js starter.

Disclosure: I maintain the linked Poszo resource. It is free and MIT-licensed.

## Validation

- `python3 scripts/generate.py`
- `python3 scripts/verify_schema.py`
- `python3 scripts/verify_anchors.py`
- `git diff --check`
- Linked repository returns HTTPS 200 with no redirect