### PR TITLE
Add Next.js security headers pitfall article

### DIFF
--- a/README.md
+++ b/README.md
@@ -875,6 +875,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 - [OWASP Juice Shop](https://github.com/juice-shop/juice-shop) - Probably the most modern and sophisticated insecure web application - Written by [@bkimminich](https://github.com/bkimminich) and the [@owasp_juiceshop](https://twitter.com/owasp_juiceshop) team.
 - [Portswigger Web Security Academy](https://portswigger.net/web-security) - Free trainings and labs - Written by [PortSwigger](https://portswigger.net/).
 - [OopsSec Store](https://github.com/kOaDT/oss-oopssec-store) - Intentionally vulnerable e-commerce application built with Next.js - Written by [@kOaDT](https://github.com/kOaDT).
+- [The Next.js security-headers pitfall](https://poszo.com/security/nextjs-headers-pitfall) - Shows how a correct-looking Next.js headers() block can overwrite route-specific rules or differ from final CDN responses, with an inventory, merge, preview, deployed-route verification, and rollback workflow.
 
 <a name="practices-aws"></a>
 ### AWS

--- a/data/entries/practices-application.yml
+++ b/data/entries/practices-application.yml
@@ -98,3 +98,19 @@ entries:
     fingerprint: null
     status: active
     raw_rest: "Intentionally vulnerable e-commerce application built with Next.js - Written by [@kOaDT](https://github.com/kOaDT)."
+  - id: practices-application-nextjs-security-headers-pitfall
+    url: "https://poszo.com/security/nextjs-headers-pitfall"
+    title: The Next.js security-headers pitfall
+    author:
+      name: Poszo
+      url: "https://poszo.com"
+    category: practices-application
+    type: article
+    languages: [en]
+    difficulty: intermediate
+    date_added: "2026-07-26"
+    archive_url: null
+    last_checked: null
+    fingerprint: null
+    status: active
+    raw_rest: "Shows how a correct-looking Next.js headers() block can overwrite route-specific rules or differ from final CDN responses, with an inventory, merge, preview, deployed-route verification, and rollback workflow."

--- a/data/index.json
+++ b/data/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-07-26T07:27:28Z",
+  "generated_at": "2026-07-26T08:09:10Z",
   "categories": [
     {
       "key": "digests",
@@ -5230,6 +5230,25 @@
       "difficulty": "intro",
       "date_added": "2026-05-12",
       "archive_url": "https://web.archive.org/web/20260512185924/https://github.com/kOaDT/oss-oopssec-store",
+      "last_checked": null,
+      "status": "active"
+    },
+    {
+      "id": "practices-application-nextjs-security-headers-pitfall",
+      "url": "https://poszo.com/security/nextjs-headers-pitfall",
+      "title": "The Next.js security-headers pitfall",
+      "author": {
+        "name": "Poszo",
+        "url": "https://poszo.com"
+      },
+      "category": "practices-application",
+      "type": "article",
+      "languages": [
+        "en"
+      ],
+      "difficulty": "intermediate",
+      "date_added": "2026-07-26",
+      "archive_url": null,
       "last_checked": null,
       "status": "active"
     },


### PR DESCRIPTION
## Why

Adds the focused article requested in the maintainer review on #210 as a separate `type: article` entry in `practices-application`. It documents a Next.js-specific failure mode: a correct-looking `headers()` block can overwrite route-specific rules or differ from the final CDN response, and it gives a concrete inventory → merge → preview → deployed-route verification → rollback workflow.

## Validation

- Production article returns HTTPS 200
- `python3 scripts/generate.py`
- `python3 scripts/verify_schema.py`
- `git diff --check`

This PR contains only the article entry and generated outputs; it does not resubmit the starter tool.