### PR TITLE
Add ONUS to web security scanning tools

### DIFF
--- a/data/entries/tools-scanning.yml
+++ b/data/entries/tools-scanning.yml
@@ -162,3 +162,19 @@ entries:
     fingerprint: null
     status: active
     raw_rest: "Free online collection of 29 client-side web security tools: web auditor, JWT attacker/decoder, CVE search, CSP evaluator, email security checker (SPF/DKIM/DMARC), subdomain scanner, and more. 100% client-side, privacy-first, open source by [@ReplikanteK](https://github.com/ReplikanteK)."
+  - id: tools-scanning-onus
+    url: "https://github.com/maverickaayush/ONUS"
+    title: ONUS
+    author:
+      name: "@maverickaayush"
+      url: "https://github.com/maverickaayush"
+    category: tools-scanning
+    type: tool
+    languages: [en, zh, jp]
+    difficulty: intro
+    date_added: "2026-07-27"
+    archive_url: null
+    last_checked: null
+    fingerprint: null
+    status: active
+    raw_rest: "Web vulnerability assessment platform that orchestrates multiple security scanners, normalizes findings, applies deterministic CVSS v3.1 scoring, and uses a local LLM to generate plain-English, step-by-step remediation guidance, by [@maverickaayush](https://github.com/maverickaayush)."


### PR DESCRIPTION
## What this PR adds / changes

Adds ONUS, a web vulnerability assessment platform, to the Scanning section.

## Self-checklist (mirrors RUBRIC.md)

- [x] URL is reachable, returns 2xx, prefers HTTPS, no redirect chain
- [x] Resource has non-trivial content depth (not a marketing or lead-gen page)
- [x] `category` value matches the resource topic
- [x] I searched for similar entries; this adds a distinct angle
- [x] All required schema fields are filled (`id`, `url`, `title`, `category`, `type`, `languages`, `difficulty`, `date_added`, `status`)
- [x] I edited `data/entries/*.yml`, NOT `README*.md` directly

## Justification (1-2 sentences)

ONUS goes beyond raw scanner output by translating vulnerability findings into plain-English, step-by-step remediation guidance, so even users with minimal security knowledge can understand the issue and take actionable steps to fix it. It uses a hybrid remediation approach while keeping CVSS v3.1 severity scoring deterministic in code rather than relying on an LLM for security-critical scoring decisions.

