### PR TITLE
Add Proxelar to the Proxy section

### DIFF
--- a/README.md
+++ b/README.md
@@ -791,6 +791,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 ### Proxy
 
 - [Charles](https://www.charlesproxy.com/) - HTTP proxy / HTTP monitor / Reverse Proxy that enables a developer to view all of the HTTP and SSL / HTTPS traffic between their machine and the Internet.
+- [Proxelar](https://github.com/emanuele-em/proxelar) - Scriptable intercepting proxy for HTTP, HTTPS, and WebSocket traffic with a terminal UI, web GUI, and Lua hooks by [@emanuele-em](https://github.com/emanuele-em).
 - [mitmproxy](https://github.com/mitmproxy/mitmproxy) - Interactive TLS-capable intercepting HTTP proxy for penetration testers and software developers by [@mitmproxy](https://github.com/mitmproxy).
 
 <a name="tools-webshell"></a>

--- a/README.md
+++ b/README.md
@@ -791,8 +791,8 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 ### Proxy
 
 - [Charles](https://www.charlesproxy.com/) - HTTP proxy / HTTP monitor / Reverse Proxy that enables a developer to view all of the HTTP and SSL / HTTPS traffic between their machine and the Internet.
-- [Proxelar](https://github.com/emanuele-em/proxelar) - Scriptable intercepting proxy for HTTP, HTTPS, and WebSocket traffic with a terminal UI, web GUI, and Lua hooks by [@emanuele-em](https://github.com/emanuele-em).
 - [mitmproxy](https://github.com/mitmproxy/mitmproxy) - Interactive TLS-capable intercepting HTTP proxy for penetration testers and software developers by [@mitmproxy](https://github.com/mitmproxy).
+- [Proxelar](https://github.com/emanuele-em/proxelar) - Single-binary intercepting proxy for HTTP, HTTPS, and WebSocket traffic that pauses and edits requests in flight, replays them, rewrites traffic with Lua hooks, and exports captures as HAR, curl, or raw HTTP, available as a terminal UI, web GUI, or headless REST API, by [@emanuele-em](https://github.com/emanuele-em).
 
 <a name="tools-webshell"></a>
 ### Webshell

--- a/data/entries/tools-proxy.yml
+++ b/data/entries/tools-proxy.yml
@@ -34,3 +34,19 @@ entries:
     fingerprint: null
     status: active
     raw_rest: "Interactive TLS-capable intercepting HTTP proxy for penetration testers and software developers by [@mitmproxy](https://github.com/mitmproxy)."
+  - id: tools-proxy-proxelar
+    url: "https://github.com/emanuele-em/proxelar"
+    title: Proxelar
+    author:
+      name: "@emanuele-em"
+      url: "https://github.com/emanuele-em"
+    category: tools-proxy
+    type: tool
+    languages: [en]
+    difficulty: intermediate
+    date_added: "2026-07-30"
+    archive_url: null
+    last_checked: null
+    fingerprint: null
+    status: active
+    raw_rest: "Single-binary intercepting proxy for HTTP, HTTPS, and WebSocket traffic that pauses and edits requests in flight, replays them, rewrites traffic with Lua hooks, and exports captures as HAR, curl, or raw HTTP, available as a terminal UI, web GUI, or headless REST API, by [@emanuele-em](https://github.com/emanuele-em)."

--- a/data/index.json
+++ b/data/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-07-26T08:35:04Z",
+  "generated_at": "2026-08-21T05:20:38Z",
   "categories": [
     {
       "key": "digests",
@@ -8138,6 +8138,25 @@
       ],
       "difficulty": "intermediate",
       "date_added": "2018-02-23",
+      "archive_url": null,
+      "last_checked": null,
+      "status": "active"
+    },
+    {
+      "id": "tools-proxy-proxelar",
+      "url": "https://github.com/emanuele-em/proxelar",
+      "title": "Proxelar",
+      "author": {
+        "name": "@emanuele-em",
+        "url": "https://github.com/emanuele-em"
+      },
+      "category": "tools-proxy",
+      "type": "tool",
+      "languages": [
+        "en"
+      ],
+      "difficulty": "intermediate",
+      "date_added": "2026-07-30",
       "archive_url": null,
       "last_checked": null,
       "status": "active"


### PR DESCRIPTION
Adds [Proxelar](https://github.com/emanuele-em/proxelar) to *Tools > Proxy*, alongside Charles and mitmproxy.

Proxelar is a single-binary intercepting proxy for HTTP, HTTPS, and WebSocket traffic. It can pause and edit requests in flight, replay them, rewrite traffic with Lua hooks, and export captures as HAR, curl, or raw HTTP with secrets redacted by default. It runs as a terminal UI, a web GUI, or a headless REST API, and also supports SOCKS5, DNS, and WireGuard capture for clients that cannot be pointed at an HTTP proxy.

Written in Rust, MIT licensed, 1k stars. The entry follows the existing format in the section, including the trailing author attribution, and is placed in alphabetical order.