### PR TITLE
Add HunterX web/API vulnerability scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,6 +695,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 - [Trust Scan](https://github.com/undeadlist/trust-scan) - URL security scanner combining threat intelligence (URLhaus, PhishTank, Spamhaus) with 40+ scam and phishing pattern detection by [@undeadlist](https://github.com/undeadlist).
 - [ZeroTrust](https://github.com/sattyamjjain/zerotrust) - Privacy-first Chrome extension that analyzes website security locally with on-device AI (WebGPU), producing trust scores from HTTPS, phishing, malicious-script, and cookie-compliance signals, by [@sattyamjjain](https://github.com/sattyamjjain).
 - [SecuriTool](https://securitool.js.org/) - Free online collection of 29 client-side web security tools: web auditor, JWT attacker/decoder, CVE search, CSP evaluator, email security checker (SPF/DKIM/DMARC), subdomain scanner, and more. 100% client-side, privacy-first, open source by [@ReplikanteK](https://github.com/ReplikanteK).
+- [HunterX](https://github.com/nullc0d30/HunterX) - Web application and API vulnerability scanner with optional AI-assisted analysis by [@nullc0d30](https://github.com/nullc0d30).
 
 <a name="tools-penetration-testing"></a>
 ### Penetration Testing

--- a/data/entries/tools-scanning.yml
+++ b/data/entries/tools-scanning.yml
@@ -162,3 +162,19 @@ entries:
     fingerprint: null
     status: active
     raw_rest: "Free online collection of 29 client-side web security tools: web auditor, JWT attacker/decoder, CVE search, CSP evaluator, email security checker (SPF/DKIM/DMARC), subdomain scanner, and more. 100% client-side, privacy-first, open source by [@ReplikanteK](https://github.com/ReplikanteK)."
+  - id: tools-scanning-hunterx
+    url: "https://github.com/nullc0d30/HunterX"
+    title: HunterX
+    author:
+      name: "@nullc0d30"
+      url: "https://github.com/nullc0d30"
+    category: tools-scanning
+    type: tool
+    languages: [en]
+    difficulty: intro
+    date_added: "2026-07-31"
+    archive_url: null
+    last_checked: null
+    fingerprint: null
+    status: active
+    raw_rest: "Web application and API vulnerability scanner with optional AI-assisted analysis by [@nullc0d30](https://github.com/nullc0d30)."

--- a/data/index.json
+++ b/data/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-07-26T08:35:04Z",
+  "generated_at": "2026-07-31T04:27:12Z",
   "categories": [
     {
       "key": "digests",
@@ -8349,6 +8349,25 @@
       "difficulty": "intro",
       "date_added": "2026-05-28",
       "archive_url": "https://web.archive.org/web/20260531111954/https://securitool.js.org/",
+      "last_checked": null,
+      "status": "active"
+    },
+    {
+      "id": "tools-scanning-hunterx",
+      "url": "https://github.com/nullc0d30/HunterX",
+      "title": "HunterX",
+      "author": {
+        "name": "@nullc0d30",
+        "url": "https://github.com/nullc0d30"
+      },
+      "category": "tools-scanning",
+      "type": "tool",
+      "languages": [
+        "en"
+      ],
+      "difficulty": "intro",
+      "date_added": "2026-07-31",
+      "archive_url": null,
       "last_checked": null,
       "status": "active"
     },


### PR DESCRIPTION
Adds [HunterX](https://github.com/nullc0d30/HunterX) to the Scanning tools section.

Why: the Scanning section lists black-box web scanners (Nuclei, WAScan, ZAP, etc.) but has no self-contained CLI scanner that covers API endpoints specifically. HunterX is a pure-Python web and API vulnerability scanner (no external scanner dependencies) with passive reconnaissance, content fuzzing, and WebSocket/GraphQL testing, installable via pip or Docker. It fills the API-endpoint gap alongside the existing web scanners.

Entry is n-only per the contribution guide; schema, anchors, and README regeneration all verified locally with generate.py and verify_schema.py.
