### PR TITLE
Add QAPractices penetration testing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -876,6 +876,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 - [Portswigger Web Security Academy](https://portswigger.net/web-security) - Free trainings and labs - Written by [PortSwigger](https://portswigger.net/).
 - [OopsSec Store](https://github.com/kOaDT/oss-oopssec-store) - Intentionally vulnerable e-commerce application built with Next.js - Written by [@kOaDT](https://github.com/kOaDT).
 - [The Next.js security-headers pitfall](https://poszo.com/security/nextjs-headers-pitfall) - Shows how a correct-looking Next.js headers() block can overwrite route-specific rules or differ from final CDN responses, with an inventory, merge, preview, deployed-route verification, and rollback workflow.
+- [Penetration Testing Guide](https://qapractices.com/documentation/penetration-testing/) - Practical guide to web application penetration testing with real-world examples and checklists.
 
 <a name="practices-aws"></a>
 ### AWS

--- a/data/entries/practices-application.yml
+++ b/data/entries/practices-application.yml
@@ -114,3 +114,19 @@ entries:
     fingerprint: null
     status: active
     raw_rest: "Shows how a correct-looking Next.js headers() block can overwrite route-specific rules or differ from final CDN responses, with an inventory, merge, preview, deployed-route verification, and rollback workflow."
+  - id: qapractices-penetration-testing-guide
+    url: "https://qapractices.com/documentation/penetration-testing/"
+    title: Penetration Testing Guide
+    author:
+      name: QAPractices
+      url: "https://qapractices.com/"
+    category: practices-application
+    type: article
+    languages: [en]
+    difficulty: intro
+    date_added: "2026-08-05"
+    archive_url: null
+    last_checked: null
+    fingerprint: null
+    status: active
+    raw_rest: "Practical guide to web application penetration testing with real-world examples and checklists."

--- a/data/index.json
+++ b/data/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-07-26T08:35:04Z",
+  "generated_at": "2026-08-05T11:51:31Z",
   "categories": [
     {
       "key": "digests",
@@ -5249,6 +5249,25 @@
       "difficulty": "intermediate",
       "date_added": "2026-07-26",
       "archive_url": "https://web.archive.org/web/20260726083016/https://poszo.com/security/nextjs-headers-pitfall",
+      "last_checked": null,
+      "status": "active"
+    },
+    {
+      "id": "qapractices-penetration-testing-guide",
+      "url": "https://qapractices.com/documentation/penetration-testing/",
+      "title": "Penetration Testing Guide",
+      "author": {
+        "name": "QAPractices",
+        "url": "https://qapractices.com/"
+      },
+      "category": "practices-application",
+      "type": "article",
+      "languages": [
+        "en"
+      ],
+      "difficulty": "intro",
+      "date_added": "2026-08-05",
+      "archive_url": null,
       "last_checked": null,
       "status": "active"
     },


### PR DESCRIPTION
Added a QAPractices Penetration Testing Guide to the Practices > Application section. It is a practical, hands-on article for web application penetration testing with real-world examples and checklists.\n\nChanges:\n- Added data/entries/practices-application.yml entry\n- Regenerated README.md, README-zh.md, README-jp.md, and data/index.json via scripts/generate.py\n- Schema and anchor verification passed.