### PR TITLE
Add QAPractices security testing resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -940,6 +940,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 - [How I got my first big bounty payout with Tesla](https://medium.com/heck-the-packet/how-i-got-my-first-big-bounty-payout-with-tesla-8d28b520162d) - Written by [@cj.fairhead](https://medium.com/@cj.fairhead).
 - [Grokking Web Application Security](https://www.manning.com/books/grokking-web-application-security) - Hands-on introduction to web application security fundamentals by Malcolm McDonald (Manning).
 - [htb-writeups](https://github.com/momenbasel/htb-writeups) - Comprehensive Hack The Box writeup collection covering 75+ web challenges including XSS, SQLi, SSTI, SSRF, and deserialization, by [@momenbasel](https://github.com/momenbasel).
+- [Security Testing](https://qapractices.com/topics/security-testing/) - Curated hub with security testing guides, checklists and tools for web application security testing.
 
 ## Code of Conduct
 

--- a/data/entries/miscellaneous.yml
+++ b/data/entries/miscellaneous.yml
@@ -642,3 +642,19 @@ entries:
     fingerprint: null
     status: active
     raw_rest: "Comprehensive Hack The Box writeup collection covering 75+ web challenges including XSS, SQLi, SSTI, SSRF, and deserialization, by [@momenbasel](https://github.com/momenbasel)."
+  - id: qapractices-security-testing
+    url: "https://qapractices.com/topics/security-testing/"
+    title: Security Testing
+    author:
+      name: QAPractices
+      url: "https://qapractices.com/"
+    category: miscellaneous
+    type: article
+    languages: [en]
+    difficulty: intro
+    date_added: "2026-08-05"
+    archive_url: null
+    last_checked: null
+    fingerprint: null
+    status: active
+    raw_rest: "Curated hub with security testing guides, checklists and tools for web application security testing."

--- a/data/index.json
+++ b/data/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-07-26T08:35:04Z",
+  "generated_at": "2026-08-05T11:53:34Z",
   "categories": [
     {
       "key": "digests",
@@ -4645,6 +4645,25 @@
       "difficulty": "intermediate",
       "date_added": "2026-05-14",
       "archive_url": "https://web.archive.org/web/20260514053737/https://github.com/momenbasel/htb-writeups",
+      "last_checked": null,
+      "status": "active"
+    },
+    {
+      "id": "qapractices-security-testing",
+      "url": "https://qapractices.com/topics/security-testing/",
+      "title": "Security Testing",
+      "author": {
+        "name": "QAPractices",
+        "url": "https://qapractices.com/"
+      },
+      "category": "miscellaneous",
+      "type": "article",
+      "languages": [
+        "en"
+      ],
+      "difficulty": "intro",
+      "date_added": "2026-08-05",
+      "archive_url": null,
       "last_checked": null,
       "status": "active"
     },


### PR DESCRIPTION
Added QAPractices Security Testing to the Miscellaneous section. It is a curated hub with security testing guides, checklists and tools for web application security testing.\n\nChanges:\n- Added data/entries/miscellaneous.yml entry\n- Regenerated README.md, README-zh.md, README-jp.md, and data/index.json via scripts/generate.py\n- Schema and anchor verification passed.