### PR TITLE
Add SpiderSuite to fuzzing tools

### DIFF
--- a/data/entries/tools-fuzzing.yml
+++ b/data/entries/tools-fuzzing.yml
@@ -146,3 +146,19 @@ entries:
     fingerprint: null
     status: active
     raw_rest: "Cross-platform Python CLI that fetches historical URLs from the Wayback CDX API and outputs normalized parameterized URLs for fuzzing, by [@aleff-github](https://github.com/aleff-github)."
+  - id: tools-fuzzing-spidersuite
+    url: "https://github.com/spidersuite/SpiderSuite"
+    title: SpiderSuite
+    author:
+      name: "3nock"
+      url: "https://github.com/3nock"
+    category: tools-fuzzing
+    type: tool
+    languages: [en, zh, jp]
+    difficulty: intermediate
+    date_added: "2026-08-06"
+    archive_url: null
+    last_checked: null
+    fingerprint: null
+    status: active
+    raw_rest: "Cross-platform web security crawler supporting standard, headless, interactive, brute-force, and archive crawling modes."


### PR DESCRIPTION
Adds [SpiderSuite](https://github.com/spidersuite/SpiderSuite) to Fuzzing tools section

## Self-checklist (mirrors RUBRIC.md)

- [x] URL is reachable, returns 2xx, prefers HTTPS, no redirect chain
- [x] Resource has non-trivial content depth (not a marketing or lead-gen page)
- [x] `category` value matches the resource topic
- [x] I searched for similar entries; this adds a distinct angle
- [x] All required schema fields are filled (`id`, `url`, `title`, `category`, `type`, `languages`, `difficulty`, `date_added`, `status`)
- [x] Edited `data/entries/*.yml`, NOT `README*.md` directly

## Justification

SpiderSuite combines multiple advanced crawling methods including headless, interactive, brute-force, and archive crawling into a unified, cross-platform interface for thorough web application security assessments. It fills a crucial gap for security researchers seeking a modern, flexible alternative for deep web Recon.