### PR TITLE
Add CC.LA — free web toolkit for WHOIS/DNS/SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,6 +650,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 - [Marshall Extensions](https://github.com/bad-antics/marshall-extensions) - OSINT and security extensions for the Marshall privacy browser, providing reconnaissance and security-testing plugins by [@bad-antics](https://github.com/bad-antics).
 - [OpenBuckets](https://openbuckets.io/) - Search engine for misconfigured public cloud storage buckets across any provider.
 - [OSINT Projects](https://osintprojects.com) - Free web toolkit for WHOIS/RDAP, DNS, IP geolocation, SSL certificate inspection and Certificate Transparency subdomain discovery.
+- [CC.LA](https://cc.la) - Free web toolkit for WHOIS/RDAP, DNS, IP WHOIS, SSL certificate inspection, name server history, and network diagnostics (ping/traceroute/MTR). No sign-up required.
 
 <a name="tools-sub-domain-enumeration"></a>
 #### Sub Domain Enumeration


### PR DESCRIPTION
Add [CC.LA](https://cc.la) to OSINT section — a free web toolkit for WHOIS, RDAP, DNS, IP WHOIS, SSL certificate inspection, name server history, and network diagnostics (ping/traceroute/MTR). No sign-up required. Similar to OSINT Projects already listed.