### PR TITLE
Add supabase-rls-leak-demo under Tools > Auditing

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,6 +615,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 - [A2SV](https://github.com/hahwul/a2sv) - Auto Scanning to SSL Vulnerability by [@hahwul](https://github.com/hahwul).
 - [prowler](https://github.com/Alfresco/prowler) - Tool for AWS security assessment, auditing and hardening by [@Alfresco](https://github.com/Alfresco).
 - [slurp](https://github.com/hehnope/slurp) - Evaluate the security of S3 buckets by [@hehnope](https://github.com/hehnope).
+- [supabase-rls-leak-demo](https://github.com/cekuu35/supabase-rls-leak-demo) - Read-only Postgres/Supabase Row-Level-Security audit (nine SELECT-only catalog queries) that flags RLS-off tables, permissive `USING(true)` policies and cross-tenant read/write leaks, plus a minimal reproducible leak-and-fix demo by [@cekuu35](https://github.com/cekuu35).
 
 <a name="tools-command-injection"></a>
 ### Command Injection


### PR DESCRIPTION
Adds [supabase-rls-leak-demo](https://github.com/cekuu35/supabase-rls-leak-demo) under **Tools > Auditing**, alongside the other access-control/config auditors (prowler, slurp).

It's a free, MIT read-only auditor for Postgres/Supabase Row Level Security: nine SELECT-only catalog queries that flag RLS-disabled tables, permissive `USING(true)` policies, and cross-tenant read/write leaks — plus a minimal reproducible leak-and-fix demo that runs entirely in PGlite (no credentials).

Followed the section format (author attribution suffix; sorted after `slurp`). Thanks for curating this list!