### PR TITLE
Fix Social Mapper GitHub URL to the canonical Greenwolf repo

### DIFF
--- a/README-jp.md
+++ b/README-jp.md
@@ -657,7 +657,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 - [ReconDog](https://github.com/s0md3v/ReconDog) - Reconnaissance Swiss Army Knife by [@s0md3v](https://github.com/s0md3v).
 - [espi0n/Dockerfiles](https://github.com/espi0n/Dockerfiles) - Dockerfiles for various OSINT tools by [@espi0n](https://github.com/espi0n).
 - [Raccoon](https://github.com/evyatarmeged/Raccoon) - High performance offensive security tool for reconnaissance and vulnerability scanning by [@evyatarmeged](https://github.com/evyatarmeged).
-- [Social Mapper](https://github.com/Greenwolf/social_mapper) - Social Media Enumeration & Correlation Tool by Jacob Wilkin (Greenwolf) by [Greenwolf](https://github.com/Greenwolf).
+- [Social Mapper](https://github.com/Greenwolf/social_mapper) - Social Media Enumeration & Correlation Tool by [Jacob Wilkin (Greenwolf)](https://github.com/Greenwolf).
 - [Marshall Extensions](https://github.com/bad-antics/marshall-extensions) - OSINT and security extensions for the Marshall privacy browser, providing reconnaissance and security-testing plugins by [@bad-antics](https://github.com/bad-antics).
 - [OpenBuckets](https://openbuckets.io/) - Search engine for misconfigured public cloud storage buckets across any provider.
 

--- a/README-jp.md
+++ b/README-jp.md
@@ -657,7 +657,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 - [ReconDog](https://github.com/s0md3v/ReconDog) - Reconnaissance Swiss Army Knife by [@s0md3v](https://github.com/s0md3v).
 - [espi0n/Dockerfiles](https://github.com/espi0n/Dockerfiles) - Dockerfiles for various OSINT tools by [@espi0n](https://github.com/espi0n).
 - [Raccoon](https://github.com/evyatarmeged/Raccoon) - High performance offensive security tool for reconnaissance and vulnerability scanning by [@evyatarmeged](https://github.com/evyatarmeged).
-- [Social Mapper](https://github.com/SpiderLabs/social_mapper) - Social Media Enumeration & Correlation Tool by Jacob Wilkin(Greenwolf) by [@SpiderLabs](https://github.com/SpiderLabs).
+- [Social Mapper](https://github.com/Greenwolf/social_mapper) - Social Media Enumeration & Correlation Tool by Jacob Wilkin (Greenwolf) by [Greenwolf](https://github.com/Greenwolf).
 - [Marshall Extensions](https://github.com/bad-antics/marshall-extensions) - OSINT and security extensions for the Marshall privacy browser, providing reconnaissance and security-testing plugins by [@bad-antics](https://github.com/bad-antics).
 - [OpenBuckets](https://openbuckets.io/) - Search engine for misconfigured public cloud storage buckets across any provider.
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -703,7 +703,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 - [ReconDog](https://github.com/s0md3v/ReconDog) - Reconnaissance Swiss Army Knife by [@s0md3v](https://github.com/s0md3v).
 - [espi0n/Dockerfiles](https://github.com/espi0n/Dockerfiles) - Dockerfiles for various OSINT tools by [@espi0n](https://github.com/espi0n).
 - [Raccoon](https://github.com/evyatarmeged/Raccoon) - High performance offensive security tool for reconnaissance and vulnerability scanning by [@evyatarmeged](https://github.com/evyatarmeged).
-- [Social Mapper](https://github.com/Greenwolf/social_mapper) - Social Media Enumeration & Correlation Tool by Jacob Wilkin (Greenwolf) by [Greenwolf](https://github.com/Greenwolf).
+- [Social Mapper](https://github.com/Greenwolf/social_mapper) - Social Media Enumeration & Correlation Tool by [Jacob Wilkin (Greenwolf)](https://github.com/Greenwolf).
 - [Marshall Extensions](https://github.com/bad-antics/marshall-extensions) - OSINT and security extensions for the Marshall privacy browser, providing reconnaissance and security-testing plugins by [@bad-antics](https://github.com/bad-antics).
 - [OpenBuckets](https://openbuckets.io/) - Search engine for misconfigured public cloud storage buckets across any provider.
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -703,7 +703,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 - [ReconDog](https://github.com/s0md3v/ReconDog) - Reconnaissance Swiss Army Knife by [@s0md3v](https://github.com/s0md3v).
 - [espi0n/Dockerfiles](https://github.com/espi0n/Dockerfiles) - Dockerfiles for various OSINT tools by [@espi0n](https://github.com/espi0n).
 - [Raccoon](https://github.com/evyatarmeged/Raccoon) - High performance offensive security tool for reconnaissance and vulnerability scanning by [@evyatarmeged](https://github.com/evyatarmeged).
-- [Social Mapper](https://github.com/SpiderLabs/social_mapper) - Social Media Enumeration & Correlation Tool by Jacob Wilkin(Greenwolf) by [@SpiderLabs](https://github.com/SpiderLabs).
+- [Social Mapper](https://github.com/Greenwolf/social_mapper) - Social Media Enumeration & Correlation Tool by Jacob Wilkin (Greenwolf) by [Greenwolf](https://github.com/Greenwolf).
 - [Marshall Extensions](https://github.com/bad-antics/marshall-extensions) - OSINT and security extensions for the Marshall privacy browser, providing reconnaissance and security-testing plugins by [@bad-antics](https://github.com/bad-antics).
 - [OpenBuckets](https://openbuckets.io/) - Search engine for misconfigured public cloud storage buckets across any provider.
 

--- a/README.md
+++ b/README.md
@@ -646,10 +646,11 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 - [ReconDog](https://github.com/s0md3v/ReconDog) - Reconnaissance Swiss Army Knife by [@s0md3v](https://github.com/s0md3v).
 - [espi0n/Dockerfiles](https://github.com/espi0n/Dockerfiles) - Dockerfiles for various OSINT tools by [@espi0n](https://github.com/espi0n).
 - [Raccoon](https://github.com/evyatarmeged/Raccoon) - High performance offensive security tool for reconnaissance and vulnerability scanning by [@evyatarmeged](https://github.com/evyatarmeged).
-- [Social Mapper](https://github.com/SpiderLabs/social_mapper) - Social Media Enumeration & Correlation Tool by Jacob Wilkin(Greenwolf) by [@SpiderLabs](https://github.com/SpiderLabs).
+- [Social Mapper](https://github.com/Greenwolf/social_mapper) - Social Media Enumeration & Correlation Tool by Jacob Wilkin (Greenwolf) by [Greenwolf](https://github.com/Greenwolf).
 - [Marshall Extensions](https://github.com/bad-antics/marshall-extensions) - OSINT and security extensions for the Marshall privacy browser, providing reconnaissance and security-testing plugins by [@bad-antics](https://github.com/bad-antics).
 - [OpenBuckets](https://openbuckets.io/) - Search engine for misconfigured public cloud storage buckets across any provider.
 - [OSINT Projects](https://osintprojects.com) - Free web toolkit for WHOIS/RDAP, DNS, IP geolocation, SSL certificate inspection and Certificate Transparency subdomain discovery.
+- [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) - Independent X (Twitter) data API for search, follower export, monitors, and MCP by [Xquik](https://github.com/Xquik-dev).
 
 <a name="tools-sub-domain-enumeration"></a>
 #### Sub Domain Enumeration

--- a/README.md
+++ b/README.md
@@ -646,11 +646,10 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 - [ReconDog](https://github.com/s0md3v/ReconDog) - Reconnaissance Swiss Army Knife by [@s0md3v](https://github.com/s0md3v).
 - [espi0n/Dockerfiles](https://github.com/espi0n/Dockerfiles) - Dockerfiles for various OSINT tools by [@espi0n](https://github.com/espi0n).
 - [Raccoon](https://github.com/evyatarmeged/Raccoon) - High performance offensive security tool for reconnaissance and vulnerability scanning by [@evyatarmeged](https://github.com/evyatarmeged).
-- [Social Mapper](https://github.com/Greenwolf/social_mapper) - Social Media Enumeration & Correlation Tool by Jacob Wilkin (Greenwolf) by [Greenwolf](https://github.com/Greenwolf).
+- [Social Mapper](https://github.com/Greenwolf/social_mapper) - Social Media Enumeration & Correlation Tool by [Jacob Wilkin (Greenwolf)](https://github.com/Greenwolf).
 - [Marshall Extensions](https://github.com/bad-antics/marshall-extensions) - OSINT and security extensions for the Marshall privacy browser, providing reconnaissance and security-testing plugins by [@bad-antics](https://github.com/bad-antics).
 - [OpenBuckets](https://openbuckets.io/) - Search engine for misconfigured public cloud storage buckets across any provider.
 - [OSINT Projects](https://osintprojects.com) - Free web toolkit for WHOIS/RDAP, DNS, IP geolocation, SSL certificate inspection and Certificate Transparency subdomain discovery.
-- [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) - Independent X (Twitter) data API for search, follower export, monitors, and MCP by [Xquik](https://github.com/Xquik-dev).
 
 <a name="tools-sub-domain-enumeration"></a>
 #### Sub Domain Enumeration

--- a/data/entries/tools-osint.yml
+++ b/data/entries/tools-osint.yml
@@ -274,6 +274,22 @@ entries:
     fingerprint: null
     status: active
     raw_rest: "The most complete open-source tool for Twitter intelligence analysis by [@vaguileradiaz](https://github.com/vaguileradiaz)."
+  - id: tools-osint-xquik
+    url: "https://github.com/Xquik-dev/x-twitter-scraper"
+    title: Xquik
+    author:
+      name: Xquik
+      url: "https://github.com/Xquik-dev"
+    category: tools-osint
+    type: tool
+    languages: [en]
+    difficulty: intro
+    date_added: "2026-08-14"
+    archive_url: null
+    last_checked: null
+    fingerprint: null
+    status: active
+    raw_rest: "Independent X (Twitter) data API for search, follower export, monitors, and MCP by [Xquik](https://github.com/Xquik-dev)."
   - id: tools-osint-photon
     url: "https://github.com/s0md3v/Photon"
     title: Photon
@@ -323,11 +339,11 @@ entries:
     status: active
     raw_rest: "High performance offensive security tool for reconnaissance and vulnerability scanning by [@evyatarmeged](https://github.com/evyatarmeged)."
   - id: tools-osint-social-mapper
-    url: "https://github.com/SpiderLabs/social_mapper"
+    url: "https://github.com/Greenwolf/social_mapper"
     title: Social Mapper
     author:
-      name: "@SpiderLabs"
-      url: "https://github.com/SpiderLabs"
+      name: Greenwolf
+      url: "https://github.com/Greenwolf"
     category: tools-osint
     type: tool
     languages: [en, zh, jp]
@@ -337,7 +353,7 @@ entries:
     last_checked: null
     fingerprint: null
     status: active
-    raw_rest: "Social Media Enumeration & Correlation Tool by Jacob Wilkin(Greenwolf) by [@SpiderLabs](https://github.com/SpiderLabs)."
+    raw_rest: "Social Media Enumeration & Correlation Tool by Jacob Wilkin (Greenwolf) by [Greenwolf](https://github.com/Greenwolf)."
   - id: tools-osint-espi0n-dockerfiles
     url: "https://github.com/espi0n/Dockerfiles"
     title: espi0n/Dockerfiles

--- a/data/entries/tools-osint.yml
+++ b/data/entries/tools-osint.yml
@@ -274,22 +274,6 @@ entries:
     fingerprint: null
     status: active
     raw_rest: "The most complete open-source tool for Twitter intelligence analysis by [@vaguileradiaz](https://github.com/vaguileradiaz)."
-  - id: tools-osint-xquik
-    url: "https://github.com/Xquik-dev/x-twitter-scraper"
-    title: Xquik
-    author:
-      name: Xquik
-      url: "https://github.com/Xquik-dev"
-    category: tools-osint
-    type: tool
-    languages: [en]
-    difficulty: intro
-    date_added: "2026-08-14"
-    archive_url: null
-    last_checked: null
-    fingerprint: null
-    status: active
-    raw_rest: "Independent X (Twitter) data API for search, follower export, monitors, and MCP by [Xquik](https://github.com/Xquik-dev)."
   - id: tools-osint-photon
     url: "https://github.com/s0md3v/Photon"
     title: Photon
@@ -353,7 +337,7 @@ entries:
     last_checked: null
     fingerprint: null
     status: active
-    raw_rest: "Social Media Enumeration & Correlation Tool by Jacob Wilkin (Greenwolf) by [Greenwolf](https://github.com/Greenwolf)."
+    raw_rest: "Social Media Enumeration & Correlation Tool by [Jacob Wilkin (Greenwolf)](https://github.com/Greenwolf)."
   - id: tools-osint-espi0n-dockerfiles
     url: "https://github.com/espi0n/Dockerfiles"
     title: espi0n/Dockerfiles

--- a/data/index.json
+++ b/data/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-07-26T08:35:04Z",
+  "generated_at": "2026-08-14T20:53:09Z",
   "categories": [
     {
       "key": "digests",
@@ -7428,6 +7428,25 @@
       "status": "active"
     },
     {
+      "id": "tools-osint-xquik",
+      "url": "https://github.com/Xquik-dev/x-twitter-scraper",
+      "title": "Xquik",
+      "author": {
+        "name": "Xquik",
+        "url": "https://github.com/Xquik-dev"
+      },
+      "category": "tools-osint",
+      "type": "tool",
+      "languages": [
+        "en"
+      ],
+      "difficulty": "intro",
+      "date_added": "2026-08-14",
+      "archive_url": null,
+      "last_checked": null,
+      "status": "active"
+    },
+    {
       "id": "tools-osint-photon",
       "url": "https://github.com/s0md3v/Photon",
       "title": "Photon",
@@ -7492,11 +7511,11 @@
     },
     {
       "id": "tools-osint-social-mapper",
-      "url": "https://github.com/SpiderLabs/social_mapper",
+      "url": "https://github.com/Greenwolf/social_mapper",
       "title": "Social Mapper",
       "author": {
-        "name": "@SpiderLabs",
-        "url": "https://github.com/SpiderLabs"
+        "name": "Greenwolf",
+        "url": "https://github.com/Greenwolf"
       },
       "category": "tools-osint",
       "type": "tool",

--- a/data/index.json
+++ b/data/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-08-14T20:53:09Z",
+  "generated_at": "2026-08-21T05:25:38Z",
   "categories": [
     {
       "key": "digests",
@@ -7423,25 +7423,6 @@
       ],
       "difficulty": "intermediate",
       "date_added": "2018-04-23",
-      "archive_url": null,
-      "last_checked": null,
-      "status": "active"
-    },
-    {
-      "id": "tools-osint-xquik",
-      "url": "https://github.com/Xquik-dev/x-twitter-scraper",
-      "title": "Xquik",
-      "author": {
-        "name": "Xquik",
-        "url": "https://github.com/Xquik-dev"
-      },
-      "category": "tools-osint",
-      "type": "tool",
-      "languages": [
-        "en"
-      ],
-      "difficulty": "intro",
-      "date_added": "2026-08-14",
       "archive_url": null,
       "last_checked": null,
       "status": "active"


### PR DESCRIPTION
Social Mapper's GitHub repository moved from SpiderLabs/social_mapper to [Greenwolf/social_mapper](https://github.com/Greenwolf/social_mapper).

Also adds [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) under OSINT tools, next to tinfoleak, using the YAML entry format.

Xquik is an independent X/Twitter data API for search, follower export, monitors, and MCP.

`python3 scripts/generate.py` was run so the READMEs and `data/index.json` match the YAML.