### PR TITLE
ci: pin diff-sentry to v0.4.2

### DIFF
--- a/.github/workflows/diff-sentry.yml
+++ b/.github/workflows/diff-sentry.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: qazbnm456/diff-sentry@v0.4.1
+      - uses: qazbnm456/diff-sentry@v0.4.2
         with:
           # `high` and above fail the check; `medium` and below are reported
           # in the job summary without gating the PR.


### PR DESCRIPTION
0.4.2 scopes the scan per file. The rules that need two signals — `pwn-request` and `detached-process-spawn` — could previously take one half from a workflow and the other from an unrelated file, which is exactly what failed #228 on a workflow that never checks out a PR.

Also in this bump:

- `allow-unsafe-pr-checkout: true` folded into `pwn-request` as a third checkout form. actions/checkout v5.1+ blocks fork-PR checkout under a privileged trigger unless a workflow opts back in with that input, so the line states the intent outright.
- The host-side baseline is scoped too — an event carries no `diff --git` headers, so the first pass at this scoped nothing there.
- Every hit names the file it came from instead of `gated.diff`.

This PR is also the smoke test: the scan running on it is v0.4.2 scanning a one-line change.