### PR TITLE
Add article on deterministic scoring in AI-assisted VAPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -878,6 +878,7 @@ Then ask any web-security question and the skill activates on topics like XSS, S
 - [Portswigger Web Security Academy](https://portswigger.net/web-security) - Free trainings and labs - Written by [PortSwigger](https://portswigger.net/).
 - [OopsSec Store](https://github.com/kOaDT/oss-oopssec-store) - Intentionally vulnerable e-commerce application built with Next.js - Written by [@kOaDT](https://github.com/kOaDT).
 - [The Next.js security-headers pitfall](https://poszo.com/security/nextjs-headers-pitfall) - Shows how a correct-looking Next.js headers() block can overwrite route-specific rules or differ from final CDN responses, with an inventory, merge, preview, deployed-route verification, and rollback workflow.
+- [Where the LLM Stops: Deterministic Scoring in an AI-Assisted VAPT Pipeline](https://aayushyadav.hashnode.dev/where-the-llm-stops-deterministic-scoring-in-an-ai-assisted-vapt-pipeline) - Technical write-up on designing an AI-assisted VAPT pipeline with deterministic CVSS scoring, passive confidence verification, and LLM-generated vulnerability explanations and remediation.
 
 <a name="practices-aws"></a>
 ### AWS

--- a/data/entries/practices-application.yml
+++ b/data/entries/practices-application.yml
@@ -114,3 +114,19 @@ entries:
     fingerprint: null
     status: active
     raw_rest: "Shows how a correct-looking Next.js headers() block can overwrite route-specific rules or differ from final CDN responses, with an inventory, merge, preview, deployed-route verification, and rollback workflow."
+  - id: practices-application-where-the-llm-stops
+    url: "https://aayushyadav.hashnode.dev/where-the-llm-stops-deterministic-scoring-in-an-ai-assisted-vapt-pipeline"
+    title: Where the LLM Stops: Deterministic Scoring in an AI-Assisted VAPT Pipeline
+    author:
+      name: Aayush Yadav
+      url: "https://github.com/maverickaayush"
+    category: practices-application
+    type: article
+    languages: [en]
+    difficulty: intermediate
+    date_added: "2026-08-22"
+    archive_url: null
+    last_checked: null
+    fingerprint: null
+    status: active
+    raw_rest: "Technical write-up on designing an AI-assisted VAPT pipeline with deterministic CVSS scoring, passive confidence verification, and LLM-generated vulnerability explanations and remediation."

--- a/data/index.json
+++ b/data/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_at": "2026-08-21T05:53:43Z",
+  "generated_at": "2026-08-22T12:10:19Z",
   "categories": [
     {
       "key": "digests",
@@ -5249,6 +5249,25 @@
       "difficulty": "intermediate",
       "date_added": "2026-07-26",
       "archive_url": "https://web.archive.org/web/20260726083016/https://poszo.com/security/nextjs-headers-pitfall",
+      "last_checked": null,
+      "status": "active"
+    },
+    {
+      "id": "practices-application-where-the-llm-stops",
+      "url": "https://aayushyadav.hashnode.dev/where-the-llm-stops-deterministic-scoring-in-an-ai-assisted-vapt-pipeline",
+      "title": "Where the LLM Stops: Deterministic Scoring in an AI-Assisted VAPT Pipeline",
+      "author": {
+        "name": "Aayush Yadav",
+        "url": "https://github.com/maverickaayush"
+      },
+      "category": "practices-application",
+      "type": "article",
+      "languages": [
+        "en"
+      ],
+      "difficulty": "intermediate",
+      "date_added": "2026-08-22",
+      "archive_url": null,
       "last_checked": null,
       "status": "active"
     },


### PR DESCRIPTION
## Summary

Adds a technical article to **Practices → Application**:

**Where the LLM Stops: Deterministic Scoring in an AI-Assisted VAPT Pipeline**

The article examines a practical trust boundary for AI-assisted vulnerability assessment: deterministic aggregation, passive confidence verification, and CVSS scoring happen before the LLM is invoked for explanations and remediation guidance.

Article:
https://aayushyadav.hashnode.dev/where-the-llm-stops-deterministic-scoring-in-an-ai-assisted-vapt-pipeline

The article is based on the implementation, testing, and validation of ONUS, with explicit discussion of limitations and what the current evidence does and does not establish.

Generated README and `data/index.json` were updated from the YAML source, and the following checks pass:

* `python3 scripts/verify_schema.py`
* `python3 scripts/verify_anchors.py`
