### PR TITLE
ci: pin diff-sentry to v0.4.3

### DIFF
--- a/.github/workflows/diff-sentry.yml
+++ b/.github/workflows/diff-sentry.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: qazbnm456/diff-sentry@v0.4.2
+      - uses: qazbnm456/diff-sentry@v0.4.3
         with:
           # `high` and above fail the check; `medium` and below are reported
           # in the job summary without gating the PR.


### PR DESCRIPTION
Dependency bump inside the action: `rlm-harness` 1.0.0 → 1.10.1, `dspy` 3.2.1 → 3.3.1. No new inputs, no interface change, `fail-on: high` unchanged.

Verified against published artifacts before moving the pin:

| check | result |
|---|---|
| `refs/tags/v0.4.3` | `f67cc093cc413828c1f1bf08cc4f34394cc2606f` |
| PyPI | 0.4.3 present, wheel 74,894 B + sdist |
| `action.yml` at the tag | `default: '0.4.3'` |
| `pyproject.toml` at the tag | `rlm-harness==1.10.1` |

The last two matter most: `action.yml`'s `version` default decides which package the `uses:` actually installs, so a tag whose default still read 0.4.2 would ship the old scanner under a new reference.

**This PR is its own test.** A ten-minor jump in the upstream kit is where a behaviour change would hide, so the diff-sentry job running on this PR is the observation — green here means the new build scans a real diff in this repo without incident.

Staying on an exact patch pin rather than `@v0`: for a scanner that gates other people's contributions, nothing should change in CI without a deliberate act.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SA7bZ24za4PiXK2q2w1Tjt